### PR TITLE
feat(roles): implementar sistema de roles e permissões

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Modules/Auth/Domain/Enums/PermissionName.php
+++ b/app/Modules/Auth/Domain/Enums/PermissionName.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Modules\Auth\Domain\Enums;
+
+enum PermissionName: string
+{
+    // Platform
+    case ManagePlatform = 'manage_platform';
+
+    // Workspace
+    case CreateWorkspace = 'create_workspace';
+    case ManageWorkspace = 'manage_workspace';
+    case DeleteWorkspace = 'delete_workspace';
+    case InviteMembers = 'invite_members';
+    case RemoveMembers = 'remove_members';
+    case AssignRoles = 'assign_roles';
+
+    // Initiatives
+    case CreateInitiative = 'create_initiative';
+    case EditInitiative = 'edit_initiative';
+    case DeleteInitiative = 'delete_initiative';
+    case ViewInitiative = 'view_initiative';
+
+    // Decisions
+    case CreateDecision = 'create_decision';
+    case EditDecision = 'edit_decision';
+    case DeleteDecision = 'delete_decision';
+    case ViewDecision = 'view_decision';
+}

--- a/app/Modules/Auth/Domain/Enums/RoleName.php
+++ b/app/Modules/Auth/Domain/Enums/RoleName.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\Auth\Domain\Enums;
+
+enum RoleName: string
+{
+    case Admin = 'admin';
+    case WorkspaceOwner = 'workspace_owner';
+    case WorkspaceMember = 'workspace_member';
+    case WorkspaceViewer = 'workspace_viewer';
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,7 +16,11 @@ return Application::configure(basePath: dirname(__DIR__))
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
         ]);
 
-        //
+        $middleware->alias([
+            'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+            'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+            'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,205 @@
+<?php
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Spatie\Permission\Models\Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Spatie\Permission\Models\Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, // default 'role_id',
+        'permission_pivot_key' => null, // default 'permission_id',
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
+    ],
+
+    /*
+     * When set to true, the method for checking permissions will be registered on the gate.
+     * Set this to false if you want to implement custom logic for checking permissions.
+     */
+
+    'register_permission_check_method' => true,
+
+    /*
+     * When set to true, Laravel\Octane\Events\OperationTerminated event listener will be registered
+     * this will refresh permissions on every TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttachedEvent
+     * \Spatie\Permission\Events\RoleDetachedEvent
+     * \Spatie\Permission\Events\PermissionAttachedEvent
+     * \Spatie\Permission\Events\PermissionDetachedEvent
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
+     * Teams Feature.
+     * When set to true the package implements teams using the 'team_foreign_key'.
+     * If you want the migrations to register the 'team_foreign_key', you must
+     * set this to true before doing the migration.
+     * If you already did the migration then you must make a new migration to also
+     * add 'team_foreign_key' to 'roles', 'model_has_roles', and 'model_has_permissions'
+     * (view the latest version of this package's migration file)
+     */
+
+    // Teams mode will be enabled in issue #3 (Workspaces) when workspace_id is available as team_id.
+    // Enabling it now would require a non-null team_id on every role assignment, which is not
+    // possible without the Workspace entity.
+    'teams' => false,
+
+    /*
+     * The class to use to resolve the permissions team id
+     */
+    'team_resolver' => \Spatie\Permission\DefaultTeamResolver::class,
+
+    /*
+     * Passport Client Credentials Grant
+     * When set to true the package will use Passports Client to check permissions
+     */
+
+    'use_passport_client_credentials' => false,
+
+    /*
+     * When set to true, the required permission names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     * See documentation to understand supported syntax.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    /*
+     * The class to use for interpreting wildcard permissions.
+     * If you need to modify delimiters, override the class and specify its name here.
+     */
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+
+    /* Cache-specific settings */
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/database/migrations/2026_03_04_213200_create_permission_tables.php
+++ b/database/migrations/2026_03_04_213200_create_permission_tables.php
@@ -1,0 +1,137 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $pivotRole = $columnNames['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
+
+        throw_if(empty($tableNames), 'Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        throw_if($teams && empty($columnNames['team_foreign_key'] ?? null), 'Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+
+        /**
+         * See `docs/prerequisites.md` for suggested lengths on 'name' and 'guard_name' if "1071 Specified key was too long" errors are encountered.
+         */
+        Schema::create($tableNames['permissions'], static function (Blueprint $table) {
+            $table->id(); // permission id
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        /**
+         * See `docs/prerequisites.md` for suggested lengths on 'name' and 'guard_name' if "1071 Specified key was too long" errors are encountered.
+         */
+        Schema::create($tableNames['roles'], static function (Blueprint $table) use ($teams, $columnNames) {
+            $table->id(); // role id
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotPermission, $teams) {
+            $table->unsignedBigInteger($pivotPermission);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->cascadeOnDelete();
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['model_has_roles'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotRole, $teams) {
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->cascadeOnDelete();
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], static function (Blueprint $table) use ($tableNames, $pivotRole, $pivotPermission) {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->cascadeOnDelete();
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->cascadeOnDelete();
+
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        throw_if(empty($tableNames), 'Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+
+        Schema::dropIfExists($tableNames['role_has_permissions']);
+        Schema::dropIfExists($tableNames['model_has_roles']);
+        Schema::dropIfExists($tableNames['model_has_permissions']);
+        Schema::dropIfExists($tableNames['roles']);
+        Schema::dropIfExists($tableNames['permissions']);
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,7 +15,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call(RoleAndPermissionSeeder::class);
 
         User::factory()->create([
             'name' => 'Test User',

--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Modules\Auth\Domain\Enums\PermissionName;
+use App\Modules\Auth\Domain\Enums\RoleName;
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+class RoleAndPermissionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        $permissions = collect(PermissionName::cases())
+            ->map(fn (PermissionName $p) => Permission::firstOrCreate(['name' => $p->value]));
+
+        $allPermissions = $permissions->pluck('name')->toArray();
+
+        $ownerPermissions = [
+            PermissionName::ManageWorkspace->value,
+            PermissionName::DeleteWorkspace->value,
+            PermissionName::InviteMembers->value,
+            PermissionName::RemoveMembers->value,
+            PermissionName::AssignRoles->value,
+            PermissionName::CreateInitiative->value,
+            PermissionName::EditInitiative->value,
+            PermissionName::DeleteInitiative->value,
+            PermissionName::ViewInitiative->value,
+            PermissionName::CreateDecision->value,
+            PermissionName::EditDecision->value,
+            PermissionName::DeleteDecision->value,
+            PermissionName::ViewDecision->value,
+        ];
+
+        $memberPermissions = [
+            PermissionName::CreateInitiative->value,
+            PermissionName::EditInitiative->value,
+            PermissionName::ViewInitiative->value,
+            PermissionName::CreateDecision->value,
+            PermissionName::EditDecision->value,
+            PermissionName::ViewDecision->value,
+        ];
+
+        $viewerPermissions = [
+            PermissionName::ViewInitiative->value,
+            PermissionName::ViewDecision->value,
+        ];
+
+        Role::firstOrCreate(['name' => RoleName::Admin->value])
+            ->syncPermissions($allPermissions);
+
+        Role::firstOrCreate(['name' => RoleName::WorkspaceOwner->value])
+            ->syncPermissions($ownerPermissions);
+
+        Role::firstOrCreate(['name' => RoleName::WorkspaceMember->value])
+            ->syncPermissions($memberPermissions);
+
+        Role::firstOrCreate(['name' => RoleName::WorkspaceViewer->value])
+            ->syncPermissions($viewerPermissions);
+    }
+}

--- a/tests/Feature/Auth/RolePermissionTest.php
+++ b/tests/Feature/Auth/RolePermissionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Auth\Domain\Enums\PermissionName;
+use App\Modules\Auth\Domain\Enums\RoleName;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function (): void {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+});
+
+test('user can be assigned a role', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(RoleName::WorkspaceMember->value);
+
+    expect($user->hasRole(RoleName::WorkspaceMember->value))->toBeTrue();
+});
+
+test('admin has all permissions', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(RoleName::Admin->value);
+
+    expect($user->can(PermissionName::ManagePlatform->value))->toBeTrue()
+        ->and($user->can(PermissionName::ManageWorkspace->value))->toBeTrue()
+        ->and($user->can(PermissionName::CreateInitiative->value))->toBeTrue()
+        ->and($user->can(PermissionName::ViewDecision->value))->toBeTrue();
+});
+
+test('workspace_owner has management permissions but not manage_platform', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(RoleName::WorkspaceOwner->value);
+
+    expect($user->can(PermissionName::ManageWorkspace->value))->toBeTrue()
+        ->and($user->can(PermissionName::InviteMembers->value))->toBeTrue()
+        ->and($user->can(PermissionName::DeleteInitiative->value))->toBeTrue()
+        ->and($user->can(PermissionName::ManagePlatform->value))->toBeFalse();
+});
+
+test('workspace_member can create and edit but not manage workspace', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(RoleName::WorkspaceMember->value);
+
+    expect($user->can(PermissionName::CreateInitiative->value))->toBeTrue()
+        ->and($user->can(PermissionName::EditDecision->value))->toBeTrue()
+        ->and($user->can(PermissionName::ManageWorkspace->value))->toBeFalse()
+        ->and($user->can(PermissionName::DeleteInitiative->value))->toBeFalse();
+});
+
+test('workspace_viewer has only view permissions', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(RoleName::WorkspaceViewer->value);
+
+    expect($user->can(PermissionName::ViewInitiative->value))->toBeTrue()
+        ->and($user->can(PermissionName::ViewDecision->value))->toBeTrue()
+        ->and($user->can(PermissionName::CreateInitiative->value))->toBeFalse()
+        ->and($user->can(PermissionName::EditDecision->value))->toBeFalse();
+});
+
+test('route protected by role middleware returns 403 for user without role', function (): void {
+    Route::get('/test-admin-only', fn () => response('ok'))
+        ->middleware(['web', 'role:admin']);
+
+    $user = User::factory()->create();
+    $user->assignRole(RoleName::WorkspaceMember->value);
+
+    $this->actingAs($user)->get('/test-admin-only')->assertForbidden();
+});
+
+test('route protected by role middleware passes for user with role', function (): void {
+    Route::get('/test-admin-pass', fn () => response('ok'))
+        ->middleware(['web', 'role:admin']);
+
+    $user = User::factory()->create();
+    $user->assignRole(RoleName::Admin->value);
+
+    $this->actingAs($user)->get('/test-admin-pass')->assertOk();
+});
+
+test('route protected by permission middleware returns 403 without permission', function (): void {
+    Route::get('/test-permission', fn () => response('ok'))
+        ->middleware(['web', 'permission:manage_platform']);
+
+    $user = User::factory()->create();
+    $user->assignRole(RoleName::WorkspaceViewer->value);
+
+    $this->actingAs($user)->get('/test-permission')->assertForbidden();
+});


### PR DESCRIPTION
## Issue

Closes #2

## O que foi feito

**Infraestrutura Spatie Permission**
- Migration publicada e executada (tabelas: roles, permissions, model_has_roles, model_has_permissions, role_has_permissions)
- Middleware `role`, `permission`, `role_or_permission` registrados em `bootstrap/app.php`
- Trait `HasRoles` adicionada ao model `User`

**Domain Enums (Auth/Domain/Enums/)**
- `RoleName`: `admin`, `workspace_owner`, `workspace_member`, `workspace_viewer`
- `PermissionName`: 15 permissões cobrindo plataforma, workspace, initiatives e decisions

**Seeder**
- `RoleAndPermissionSeeder` cria todas as roles e permissões com mapeamento completo
- `DatabaseSeeder` chama o seeder por padrão

**Observação: Spatie Teams**
Teams mode (`teams = false` por ora) será habilitado na issue #3 (Workspaces) quando o `workspace_id` estiver disponível para ser usado como `team_id`. Habilitar antes exigiria `team_id NOT NULL` em todas as atribuições de role, incluindo o `admin` global — sem uma entidade de workspace, isso é inviável.

## Critérios de aceite

- [x] Roles assignáveis a usuários
- [x] Permissões enforçáveis em controllers (`$user->can(...)`)
- [x] Middleware de proteção ativo (`role:admin`, `permission:manage_platform`)

## Testes

33 testes passando (81 assertions), incluindo 8 novos testes de roles/permissions.