### PR TITLE
feat(workspaces): implementar módulo Workspace com Spatie Teams mode

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Modules\Workspaces\Infrastructure\Workspace;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
@@ -45,5 +47,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function ownedWorkspaces(): HasMany
+    {
+        return $this->hasMany(Workspace::class, 'owner_id');
     }
 }

--- a/app/Modules/Workspaces/Application/Actions/CreateWorkspace.php
+++ b/app/Modules/Workspaces/Application/Actions/CreateWorkspace.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Modules\Workspaces\Application\Actions;
+
+use App\Models\User;
+use App\Modules\Auth\Domain\Enums\RoleName;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Support\Str;
+
+class CreateWorkspace
+{
+    public function execute(User $owner, string $name): Workspace
+    {
+        $workspace = Workspace::create([
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.Str::random(6),
+            'owner_id' => $owner->id,
+        ]);
+
+        setPermissionsTeamId($workspace->id);
+        $owner->assignRole(RoleName::WorkspaceOwner->value);
+
+        return $workspace;
+    }
+}

--- a/app/Modules/Workspaces/Infrastructure/Workspace.php
+++ b/app/Modules/Workspaces/Infrastructure/Workspace.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Modules\Workspaces\Infrastructure;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Workspace extends Model
+{
+    /** @use HasFactory<\Database\Factories\WorkspaceFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'owner_id',
+    ];
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'owner_id');
+    }
+}

--- a/app/Modules/Workspaces/Interfaces/Http/Controllers/WorkspaceController.php
+++ b/app/Modules/Workspaces/Interfaces/Http/Controllers/WorkspaceController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\Workspaces\Interfaces\Http\Controllers;
+
+use App\Modules\Workspaces\Application\Actions\CreateWorkspace;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use App\Modules\Workspaces\Interfaces\Http\Requests\CreateWorkspaceRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class WorkspaceController extends Controller
+{
+    public function store(CreateWorkspaceRequest $request, CreateWorkspace $action): RedirectResponse
+    {
+        $workspace = $action->execute(
+            owner: $request->user(),
+            name: $request->validated('name'),
+        );
+
+        return redirect()->route('workspaces.show', $workspace)
+            ->with('success', 'Workspace criado com sucesso.');
+    }
+
+    public function show(Workspace $workspace): Response
+    {
+        return Inertia::render('Workspaces/Show', [
+            'workspace' => $workspace,
+        ]);
+    }
+}

--- a/app/Modules/Workspaces/Interfaces/Http/Requests/CreateWorkspaceRequest.php
+++ b/app/Modules/Workspaces/Interfaces/Http/Requests/CreateWorkspaceRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Modules\Workspaces\Interfaces\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateWorkspaceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'min:3', 'max:100'],
+        ];
+    }
+}

--- a/app/Modules/Workspaces/Interfaces/routes.php
+++ b/app/Modules/Workspaces/Interfaces/routes.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Modules\Workspaces\Interfaces\Http\Controllers\WorkspaceController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('auth')->group(function (): void {
+    Route::post('/workspaces', [WorkspaceController::class, 'store'])->name('workspaces.store');
+    Route::get('/workspaces/{workspace}', [WorkspaceController::class, 'show'])->name('workspaces.show');
+});

--- a/config/permission.php
+++ b/config/permission.php
@@ -131,10 +131,9 @@ return [
      * (view the latest version of this package's migration file)
      */
 
-    // Teams mode will be enabled in issue #3 (Workspaces) when workspace_id is available as team_id.
-    // Enabling it now would require a non-null team_id on every role assignment, which is not
-    // possible without the Workspace entity.
-    'teams' => false,
+    // Teams mode enabled: workspace_id is used as team_id for workspace-scoped roles.
+    // Global roles (e.g. admin) are assigned with team_id = 0 (setPermissionsTeamId(0)).
+    'teams' => true,
 
     /*
      * The class to use to resolve the permissions team id

--- a/database/migrations/2026_03_05_000001_create_workspaces_table.php
+++ b/database/migrations/2026_03_05_000001_create_workspaces_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('workspaces', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->foreignId('owner_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('workspaces');
+    }
+};

--- a/database/seeders/RoleAndPermissionSeeder.php
+++ b/database/seeders/RoleAndPermissionSeeder.php
@@ -15,6 +15,9 @@ class RoleAndPermissionSeeder extends Seeder
     {
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
 
+        // Ensure global context: all role definitions use team_id = null.
+        setPermissionsTeamId(null);
+
         $permissions = collect(PermissionName::cases())
             ->map(fn (PermissionName $p) => Permission::firstOrCreate(['name' => $p->value]));
 
@@ -50,16 +53,11 @@ class RoleAndPermissionSeeder extends Seeder
             PermissionName::ViewDecision->value,
         ];
 
-        Role::firstOrCreate(['name' => RoleName::Admin->value])
-            ->syncPermissions($allPermissions);
-
-        Role::firstOrCreate(['name' => RoleName::WorkspaceOwner->value])
-            ->syncPermissions($ownerPermissions);
-
-        Role::firstOrCreate(['name' => RoleName::WorkspaceMember->value])
-            ->syncPermissions($memberPermissions);
-
-        Role::firstOrCreate(['name' => RoleName::WorkspaceViewer->value])
-            ->syncPermissions($viewerPermissions);
+        // Roles are defined globally (team_id = null) and shared across workspaces.
+        // User-role assignments in model_has_roles carry the team_id (workspace or 0 for global).
+        Role::findOrCreate(RoleName::Admin->value)->syncPermissions($allPermissions);
+        Role::findOrCreate(RoleName::WorkspaceOwner->value)->syncPermissions($ownerPermissions);
+        Role::findOrCreate(RoleName::WorkspaceMember->value)->syncPermissions($memberPermissions);
+        Role::findOrCreate(RoleName::WorkspaceViewer->value)->syncPermissions($viewerPermissions);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,3 +18,4 @@ Route::get('/dashboard', function () {
 })->middleware(['auth', 'verified'])->name('dashboard');
 
 require __DIR__.'/auth.php';
+require app_path('Modules/Workspaces/Interfaces/routes.php');

--- a/tests/Feature/Auth/RolePermissionTest.php
+++ b/tests/Feature/Auth/RolePermissionTest.php
@@ -5,12 +5,18 @@ use App\Modules\Auth\Domain\Enums\PermissionName;
 use App\Modules\Auth\Domain\Enums\RoleName;
 use Spatie\Permission\PermissionRegistrar;
 
+// Team ID conventions used in tests:
+//   0   → global context (admin role, platform-level operations)
+//   1   → simulated workspace context (workspace-scoped roles)
+
 beforeEach(function (): void {
     app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    setPermissionsTeamId(null);
     $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
 });
 
 test('user can be assigned a role', function (): void {
+    setPermissionsTeamId(1);
     $user = User::factory()->create();
     $user->assignRole(RoleName::WorkspaceMember->value);
 
@@ -18,6 +24,7 @@ test('user can be assigned a role', function (): void {
 });
 
 test('admin has all permissions', function (): void {
+    setPermissionsTeamId(0);
     $user = User::factory()->create();
     $user->assignRole(RoleName::Admin->value);
 
@@ -28,6 +35,7 @@ test('admin has all permissions', function (): void {
 });
 
 test('workspace_owner has management permissions but not manage_platform', function (): void {
+    setPermissionsTeamId(1);
     $user = User::factory()->create();
     $user->assignRole(RoleName::WorkspaceOwner->value);
 
@@ -38,6 +46,7 @@ test('workspace_owner has management permissions but not manage_platform', funct
 });
 
 test('workspace_member can create and edit but not manage workspace', function (): void {
+    setPermissionsTeamId(1);
     $user = User::factory()->create();
     $user->assignRole(RoleName::WorkspaceMember->value);
 
@@ -48,6 +57,7 @@ test('workspace_member can create and edit but not manage workspace', function (
 });
 
 test('workspace_viewer has only view permissions', function (): void {
+    setPermissionsTeamId(1);
     $user = User::factory()->create();
     $user->assignRole(RoleName::WorkspaceViewer->value);
 
@@ -61,6 +71,7 @@ test('route protected by role middleware returns 403 for user without role', fun
     Route::get('/test-admin-only', fn () => response('ok'))
         ->middleware(['web', 'role:admin']);
 
+    setPermissionsTeamId(1);
     $user = User::factory()->create();
     $user->assignRole(RoleName::WorkspaceMember->value);
 
@@ -71,6 +82,7 @@ test('route protected by role middleware passes for user with role', function ()
     Route::get('/test-admin-pass', fn () => response('ok'))
         ->middleware(['web', 'role:admin']);
 
+    setPermissionsTeamId(0);
     $user = User::factory()->create();
     $user->assignRole(RoleName::Admin->value);
 
@@ -81,6 +93,7 @@ test('route protected by permission middleware returns 403 without permission', 
     Route::get('/test-permission', fn () => response('ok'))
         ->middleware(['web', 'permission:manage_platform']);
 
+    setPermissionsTeamId(1);
     $user = User::factory()->create();
     $user->assignRole(RoleName::WorkspaceViewer->value);
 

--- a/tests/Feature/Workspaces/CreateWorkspaceTest.php
+++ b/tests/Feature/Workspaces/CreateWorkspaceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Auth\Domain\Enums\RoleName;
+use App\Modules\Workspaces\Application\Actions\CreateWorkspace;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function (): void {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    setPermissionsTeamId(null);
+    $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+});
+
+test('workspace can be created with name and slug', function (): void {
+    $owner = User::factory()->create();
+
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'My Workspace');
+
+    expect($workspace)->toBeInstanceOf(Workspace::class)
+        ->and($workspace->name)->toBe('My Workspace')
+        ->and($workspace->slug)->toContain('my-workspace')
+        ->and($workspace->owner_id)->toBe($owner->id);
+});
+
+test('workspace creator is automatically assigned workspace_owner role', function (): void {
+    $owner = User::factory()->create();
+
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    expect($owner->hasRole(RoleName::WorkspaceOwner->value))->toBeTrue();
+});
+
+test('workspace_owner role is scoped to the workspace', function (): void {
+    $owner = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Workspace A');
+
+    setPermissionsTeamId($workspace->id);
+    expect($owner->hasRole(RoleName::WorkspaceOwner->value))->toBeTrue()
+        ->and($otherUser->hasRole(RoleName::WorkspaceOwner->value))->toBeFalse();
+});
+
+test('workspace owner role from one workspace does not bleed into another', function (): void {
+    $owner = User::factory()->create();
+
+    $workspaceA = app(CreateWorkspace::class)->execute($owner, 'Workspace A');
+    $workspaceB = app(CreateWorkspace::class)->execute(User::factory()->create(), 'Workspace B');
+
+    setPermissionsTeamId($workspaceA->id);
+    expect($owner->hasRole(RoleName::WorkspaceOwner->value))->toBeTrue();
+
+    // Reload relation to avoid Eloquent's cached roles from previous context.
+    setPermissionsTeamId($workspaceB->id);
+    expect($owner->fresh()->hasRole(RoleName::WorkspaceOwner->value))->toBeFalse();
+});
+
+test('workspace can be created via POST /workspaces', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post('/workspaces', ['name' => 'Test Workspace'])
+        ->assertRedirect();
+
+    expect(Workspace::where('owner_id', $user->id)->exists())->toBeTrue();
+});
+
+test('workspace creation requires authentication', function (): void {
+    $this->post('/workspaces', ['name' => 'Test Workspace'])
+        ->assertRedirect('/login');
+});
+
+test('workspace name is required', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post('/workspaces', ['name' => ''])
+        ->assertSessionHasErrors('name');
+});
+
+test('workspace name must be at least 3 characters', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post('/workspaces', ['name' => 'AB'])
+        ->assertSessionHasErrors('name');
+});


### PR DESCRIPTION
- Habilita teams mode no Spatie Permission (teams=true)
- Cria migration e model Eloquent para workspaces
- Adiciona CreateWorkspace action (cria workspace + atribui workspace_owner)
- Adiciona WorkspaceController, CreateWorkspaceRequest e rotas do módulo
- Adiciona relacionamento ownedWorkspaces no User model
- Atualiza RoleAndPermissionSeeder para usar findOrCreate com team_id=null
- Atualiza RolePermissionTest para usar contexto de team (0=global, 1=workspace)
- 8 novos testes de criação de workspace (todos passando)