### PR TITLE
feat(workspaces): implementar middleware de contexto de workspace

### DIFF
--- a/app/Modules/Workspaces/Domain/Traits/BelongsToWorkspace.php
+++ b/app/Modules/Workspaces/Domain/Traits/BelongsToWorkspace.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Modules\Workspaces\Domain\Traits;
+
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Trait for Eloquent models that belong to a workspace (tenant scope).
+ *
+ * Usage: add `use BelongsToWorkspace;` to any tenant model.
+ * The model's table must have a `workspace_id` FK column.
+ */
+trait BelongsToWorkspace
+{
+    public static function bootBelongsToWorkspace(): void
+    {
+        static::addGlobalScope('workspace', function (Builder $query): void {
+            if (app()->bound('current.workspace')) {
+                $query->where('workspace_id', app('current.workspace')->id);
+            }
+        });
+
+        static::creating(function (self $model): void {
+            if (! isset($model->workspace_id) && app()->bound('current.workspace')) {
+                $model->workspace_id = app('current.workspace')->id;
+            }
+        });
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+}

--- a/app/Modules/Workspaces/Infrastructure/Workspace.php
+++ b/app/Modules/Workspaces/Infrastructure/Workspace.php
@@ -3,6 +3,8 @@
 namespace App\Modules\Workspaces\Infrastructure;
 
 use App\Models\User;
+use Database\Factories\WorkspaceFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -17,6 +19,11 @@ class Workspace extends Model
         'slug',
         'owner_id',
     ];
+
+    protected static function newFactory(): Factory
+    {
+        return WorkspaceFactory::new();
+    }
 
     public function owner(): BelongsTo
     {

--- a/app/Modules/Workspaces/Interfaces/Http/Middleware/SetWorkspaceContext.php
+++ b/app/Modules/Workspaces/Interfaces/Http/Middleware/SetWorkspaceContext.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Modules\Workspaces\Interfaces\Http\Middleware;
+
+use App\Modules\Auth\Domain\Enums\RoleName;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetWorkspaceContext
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $workspace = $request->route('workspace');
+
+        if (! $workspace instanceof Workspace) {
+            abort(400, 'Workspace context missing from route.');
+        }
+
+        $user = $request->user();
+
+        // Global admins (team_id=0) can access any workspace.
+        setPermissionsTeamId(0);
+        if ($user->hasRole(RoleName::Admin->value)) {
+            setPermissionsTeamId($workspace->id);
+            app()->instance('current.workspace', $workspace);
+
+            return $next($request);
+        }
+
+        // Workspace members must have any workspace-scoped role for this workspace.
+        // Unset cached roles to avoid stale results from the admin check above.
+        $user->unsetRelation('roles');
+        setPermissionsTeamId($workspace->id);
+        $workspaceRoles = [
+            RoleName::WorkspaceOwner->value,
+            RoleName::WorkspaceMember->value,
+            RoleName::WorkspaceViewer->value,
+        ];
+
+        if (! $user->hasAnyRole($workspaceRoles)) {
+            abort(403, 'Você não tem acesso a este workspace.');
+        }
+
+        app()->instance('current.workspace', $workspace);
+
+        return $next($request);
+    }
+}

--- a/app/Modules/Workspaces/Interfaces/routes.php
+++ b/app/Modules/Workspaces/Interfaces/routes.php
@@ -5,5 +5,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth')->group(function (): void {
     Route::post('/workspaces', [WorkspaceController::class, 'store'])->name('workspaces.store');
-    Route::get('/workspaces/{workspace}', [WorkspaceController::class, 'show'])->name('workspaces.show');
+
+    Route::middleware('workspace.context')->group(function (): void {
+        Route::get('/workspaces/{workspace}', [WorkspaceController::class, 'show'])->name('workspaces.show');
+    });
 });

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,6 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
             'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
             'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
+            'workspace.context' => \App\Modules\Workspaces\Interfaces\Http\Middleware\SetWorkspaceContext::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/database/factories/WorkspaceFactory.php
+++ b/database/factories/WorkspaceFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Workspace>
+ */
+class WorkspaceFactory extends Factory
+{
+    protected $model = Workspace::class;
+
+    public function definition(): array
+    {
+        $name = fake()->company();
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.Str::random(6),
+            'owner_id' => User::factory(),
+        ];
+    }
+}

--- a/resources/js/Pages/Workspaces/Show.tsx
+++ b/resources/js/Pages/Workspaces/Show.tsx
@@ -1,0 +1,36 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+interface Workspace {
+    id: number;
+    name: string;
+    slug: string;
+}
+
+interface Props {
+    workspace: Workspace;
+}
+
+export default function Show({ workspace }: Props) {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    {workspace.name}
+                </h2>
+            }
+        >
+            <Head title={workspace.name} />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            Workspace: {workspace.name}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/tests/Feature/Workspaces/WorkspaceMiddlewareTest.php
+++ b/tests/Feature/Workspaces/WorkspaceMiddlewareTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Auth\Domain\Enums\RoleName;
+use App\Modules\Workspaces\Application\Actions\CreateWorkspace;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function (): void {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    setPermissionsTeamId(null);
+    $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+});
+
+test('workspace member can access workspace route', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Test Workspace');
+
+    $this->actingAs($owner)
+        ->get("/workspaces/{$workspace->id}")
+        ->assertStatus(200);
+});
+
+test('unauthenticated user cannot access workspace route', function (): void {
+    $workspace = Workspace::factory()->create();
+
+    $this->get("/workspaces/{$workspace->id}")
+        ->assertRedirect('/login');
+});
+
+test('user without workspace role gets 403', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Test Workspace');
+
+    $outsider = User::factory()->create();
+
+    $this->actingAs($outsider)
+        ->get("/workspaces/{$workspace->id}")
+        ->assertForbidden();
+});
+
+test('global admin can access any workspace', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Test Workspace');
+
+    $admin = User::factory()->create();
+    setPermissionsTeamId(0);
+    $admin->assignRole(RoleName::Admin->value);
+
+    $this->actingAs($admin)
+        ->get("/workspaces/{$workspace->id}")
+        ->assertStatus(200);
+});
+
+test('workspace access is isolated per workspace per request', function (): void {
+    $ownerA = User::factory()->create();
+    $ownerB = User::factory()->create();
+    $workspaceA = app(CreateWorkspace::class)->execute($ownerA, 'Workspace A');
+    $workspaceB = app(CreateWorkspace::class)->execute($ownerB, 'Workspace B');
+
+    // ownerA can access workspaceA but is blocked from workspaceB
+    $this->actingAs($ownerA)->get("/workspaces/{$workspaceA->id}")->assertOk();
+    $this->actingAs($ownerA)->get("/workspaces/{$workspaceB->id}")->assertForbidden();
+
+    // ownerB has the inverse access
+    $this->actingAs($ownerB)->get("/workspaces/{$workspaceB->id}")->assertOk();
+    $this->actingAs($ownerB)->get("/workspaces/{$workspaceA->id}")->assertForbidden();
+});
+
+test('workspace viewer role grants read access', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Test Workspace');
+
+    $viewer = User::factory()->create();
+    setPermissionsTeamId($workspace->id);
+    $viewer->assignRole(RoleName::WorkspaceViewer->value);
+
+    $this->actingAs($viewer)
+        ->get("/workspaces/{$workspace->id}")
+        ->assertStatus(200);
+});


### PR DESCRIPTION
- Adiciona SetWorkspaceContext middleware que resolve e valida o workspace por request
- Admins globais (team_id=0) têm acesso a qualquer workspace
- Usuários sem role no workspace recebem 403
- Armazena workspace no container via app()->instance('current.workspace')
- Adiciona alias workspace.context no bootstrap/app.php
- Cria BelongsToWorkspace trait para futuros tenant models (global scope + auto-fill)
- Cria WorkspaceFactory para testes
- 6 novos testes de middleware (todos passando)