### PR TITLE
feat(teams): implementar módulo Teams com membership e role validation

### DIFF
--- a/app/Modules/Teams/Application/Actions/AddTeamMember.php
+++ b/app/Modules/Teams/Application/Actions/AddTeamMember.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\Teams\Application\Actions;
+
+use App\Models\User;
+use App\Modules\Auth\Domain\Enums\RoleName;
+use App\Modules\Teams\Infrastructure\Team;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class AddTeamMember
+{
+    /**
+     * @throws AuthorizationException
+     */
+    public function execute(Team $team, User $userToAdd): void
+    {
+        // Only workspace members (any role) can be added to teams.
+        $workspaceRoles = [
+            RoleName::WorkspaceOwner->value,
+            RoleName::WorkspaceMember->value,
+            RoleName::WorkspaceViewer->value,
+        ];
+
+        if (! $userToAdd->hasAnyRole($workspaceRoles)) {
+            throw new AuthorizationException('User is not a member of this workspace.');
+        }
+
+        if (! $team->members()->where('user_id', $userToAdd->id)->exists()) {
+            $team->members()->attach($userToAdd->id);
+        }
+    }
+}

--- a/app/Modules/Teams/Application/Actions/CreateTeam.php
+++ b/app/Modules/Teams/Application/Actions/CreateTeam.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Modules\Teams\Application\Actions;
+
+use App\Models\User;
+use App\Modules\Teams\Infrastructure\Team;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Support\Str;
+
+class CreateTeam
+{
+    public function execute(Workspace $workspace, User $owner, string $name): Team
+    {
+        $team = Team::create([
+            'workspace_id' => $workspace->id,
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.Str::random(4),
+            'owner_id' => $owner->id,
+        ]);
+
+        $team->members()->attach($owner->id);
+
+        return $team;
+    }
+}

--- a/app/Modules/Teams/Application/Actions/RemoveTeamMember.php
+++ b/app/Modules/Teams/Application/Actions/RemoveTeamMember.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Modules\Teams\Application\Actions;
+
+use App\Models\User;
+use App\Modules\Teams\Infrastructure\Team;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class RemoveTeamMember
+{
+    /**
+     * @throws AuthorizationException
+     */
+    public function execute(Team $team, User $userToRemove): void
+    {
+        if ($team->owner_id === $userToRemove->id) {
+            throw new AuthorizationException('Cannot remove the team owner.');
+        }
+
+        $team->members()->detach($userToRemove->id);
+    }
+}

--- a/app/Modules/Teams/Infrastructure/Team.php
+++ b/app/Modules/Teams/Infrastructure/Team.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Modules\Teams\Infrastructure;
+
+use App\Models\User;
+use App\Modules\Workspaces\Domain\Traits\BelongsToWorkspace;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Database\Factories\TeamFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Team extends Model
+{
+    /** @use HasFactory<TeamFactory> */
+    use BelongsToWorkspace, HasFactory;
+
+    protected $fillable = [
+        'workspace_id',
+        'name',
+        'slug',
+        'owner_id',
+    ];
+
+    protected static function newFactory(): Factory
+    {
+        return TeamFactory::new();
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'owner_id');
+    }
+
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'team_members')->withTimestamps();
+    }
+}

--- a/app/Modules/Teams/Interfaces/Http/Controllers/TeamController.php
+++ b/app/Modules/Teams/Interfaces/Http/Controllers/TeamController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Modules\Teams\Interfaces\Http\Controllers;
+
+use App\Modules\Teams\Application\Actions\CreateTeam;
+use App\Modules\Teams\Infrastructure\Team;
+use App\Modules\Teams\Interfaces\Http\Requests\CreateTeamRequest;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TeamController extends Controller
+{
+    public function index(Workspace $workspace): Response
+    {
+        $teams = $workspace->teams()
+            ->with('owner')
+            ->withCount('members')
+            ->get();
+
+        return Inertia::render('Teams/Index', [
+            'workspace' => $workspace,
+            'teams' => $teams,
+        ]);
+    }
+
+    public function store(CreateTeamRequest $request, Workspace $workspace, CreateTeam $action): RedirectResponse
+    {
+        $team = $action->execute(
+            workspace: $workspace,
+            owner: $request->user(),
+            name: $request->validated('name'),
+        );
+
+        return redirect()->route('teams.show', [$workspace, $team])
+            ->with('success', 'Time criado com sucesso.');
+    }
+
+    public function show(Workspace $workspace, Team $team): Response
+    {
+        abort_unless($team->workspace_id === $workspace->id, 404);
+
+        return Inertia::render('Teams/Show', [
+            'workspace' => $workspace,
+            'team' => $team->load('members', 'owner'),
+        ]);
+    }
+}

--- a/app/Modules/Teams/Interfaces/Http/Controllers/TeamMemberController.php
+++ b/app/Modules/Teams/Interfaces/Http/Controllers/TeamMemberController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Modules\Teams\Interfaces\Http\Controllers;
+
+use App\Models\User;
+use App\Modules\Auth\Domain\Enums\PermissionName;
+use App\Modules\Teams\Application\Actions\AddTeamMember;
+use App\Modules\Teams\Application\Actions\RemoveTeamMember;
+use App\Modules\Teams\Infrastructure\Team;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class TeamMemberController extends Controller
+{
+    public function store(Request $request, Workspace $workspace, Team $team, AddTeamMember $action): RedirectResponse
+    {
+        abort_unless($request->user()->can(PermissionName::InviteMembers->value), 403);
+        abort_unless($team->workspace_id === $workspace->id, 404);
+
+        $request->validate(['user_id' => ['required', 'integer', 'exists:users,id']]);
+
+        $userToAdd = User::findOrFail($request->integer('user_id'));
+
+        $action->execute($team, $userToAdd);
+
+        return back()->with('success', 'Membro adicionado ao time.');
+    }
+
+    public function destroy(Request $request, Workspace $workspace, Team $team, User $user, RemoveTeamMember $action): RedirectResponse
+    {
+        abort_unless($request->user()->can(PermissionName::RemoveMembers->value), 403);
+        abort_unless($team->workspace_id === $workspace->id, 404);
+
+        $action->execute($team, $user);
+
+        return back()->with('success', 'Membro removido do time.');
+    }
+}

--- a/app/Modules/Teams/Interfaces/Http/Requests/CreateTeamRequest.php
+++ b/app/Modules/Teams/Interfaces/Http/Requests/CreateTeamRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Modules\Teams\Interfaces\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateTeamRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('manage_workspace');
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'min:2', 'max:100'],
+        ];
+    }
+}

--- a/app/Modules/Teams/Interfaces/routes.php
+++ b/app/Modules/Teams/Interfaces/routes.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Modules\Teams\Interfaces\Http\Controllers\TeamController;
+use App\Modules\Teams\Interfaces\Http\Controllers\TeamMemberController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['auth', 'workspace.context'])->group(function (): void {
+    Route::get('/workspaces/{workspace}/teams', [TeamController::class, 'index'])->name('teams.index');
+    Route::post('/workspaces/{workspace}/teams', [TeamController::class, 'store'])->name('teams.store');
+    Route::get('/workspaces/{workspace}/teams/{team}', [TeamController::class, 'show'])->name('teams.show');
+
+    Route::post('/workspaces/{workspace}/teams/{team}/members', [TeamMemberController::class, 'store'])->name('teams.members.store');
+    Route::delete('/workspaces/{workspace}/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('teams.members.destroy');
+});

--- a/app/Modules/Workspaces/Infrastructure/Workspace.php
+++ b/app/Modules/Workspaces/Infrastructure/Workspace.php
@@ -3,11 +3,13 @@
 namespace App\Modules\Workspaces\Infrastructure;
 
 use App\Models\User;
+use App\Modules\Teams\Infrastructure\Team;
 use Database\Factories\WorkspaceFactory;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Workspace extends Model
 {
@@ -28,5 +30,10 @@ class Workspace extends Model
     public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'owner_id');
+    }
+
+    public function teams(): HasMany
+    {
+        return $this->hasMany(Team::class);
     }
 }

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Modules\Teams\Infrastructure\Team;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Team>
+ */
+class TeamFactory extends Factory
+{
+    protected $model = Team::class;
+
+    public function definition(): array
+    {
+        $name = fake()->words(2, true);
+
+        return [
+            'workspace_id' => Workspace::factory(),
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.Str::random(4),
+            'owner_id' => \App\Models\User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_03_05_000002_create_teams_table.php
+++ b/database/migrations/2026_03_05_000002_create_teams_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained('workspaces')->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug');
+            $table->foreignId('owner_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['workspace_id', 'slug']);
+        });
+
+        Schema::create('team_members', function (Blueprint $table): void {
+            $table->foreignId('team_id')->constrained('teams')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->primary(['team_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('team_members');
+        Schema::dropIfExists('teams');
+    }
+};

--- a/resources/js/Pages/Teams/Index.tsx
+++ b/resources/js/Pages/Teams/Index.tsx
@@ -1,0 +1,53 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+interface Team {
+    id: number;
+    name: string;
+    slug: string;
+    members_count: number;
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    teams: Team[];
+}
+
+export default function Index({ workspace, teams }: Props) {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Times – {workspace.name}
+                </h2>
+            }
+        >
+            <Head title={`Times – ${workspace.name}`} />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            {teams.length === 0 ? (
+                                <p>Nenhum time criado ainda.</p>
+                            ) : (
+                                <ul>
+                                    {teams.map((team) => (
+                                        <li key={team.id}>
+                                            {team.name} ({team.members_count} membros)
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Teams/Show.tsx
+++ b/resources/js/Pages/Teams/Show.tsx
@@ -1,0 +1,54 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+interface Member {
+    id: number;
+    name: string;
+    email: string;
+}
+
+interface Team {
+    id: number;
+    name: string;
+    slug: string;
+    members: Member[];
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    team: Team;
+}
+
+export default function Show({ workspace, team }: Props) {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    {team.name}
+                </h2>
+            }
+        >
+            <Head title={team.name} />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            <h3 className="font-semibold mb-4">Membros</h3>
+                            <ul>
+                                {team.members.map((member) => (
+                                    <li key={member.id}>{member.name}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,3 +19,4 @@ Route::get('/dashboard', function () {
 
 require __DIR__.'/auth.php';
 require app_path('Modules/Workspaces/Interfaces/routes.php');
+require app_path('Modules/Teams/Interfaces/routes.php');

--- a/tests/Feature/Teams/CreateTeamTest.php
+++ b/tests/Feature/Teams/CreateTeamTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Auth\Domain\Enums\RoleName;
+use App\Modules\Teams\Application\Actions\CreateTeam;
+use App\Modules\Teams\Infrastructure\Team;
+use App\Modules\Workspaces\Application\Actions\CreateWorkspace;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function (): void {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    setPermissionsTeamId(null);
+    $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+});
+
+test('workspace owner can create a team', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $team = app(CreateTeam::class)->execute($workspace, $owner, 'Engineering');
+
+    expect($team)->toBeInstanceOf(Team::class)
+        ->and($team->name)->toBe('Engineering')
+        ->and($team->workspace_id)->toBe($workspace->id)
+        ->and($team->owner_id)->toBe($owner->id);
+});
+
+test('team creator is automatically added as a member', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $team = app(CreateTeam::class)->execute($workspace, $owner, 'Engineering');
+
+    expect($team->members()->where('user_id', $owner->id)->exists())->toBeTrue();
+});
+
+test('team belongs to the correct workspace', function (): void {
+    $ownerA = User::factory()->create();
+    $ownerB = User::factory()->create();
+    $workspaceA = app(CreateWorkspace::class)->execute($ownerA, 'Workspace A');
+    $workspaceB = app(CreateWorkspace::class)->execute($ownerB, 'Workspace B');
+
+    setPermissionsTeamId($workspaceA->id);
+    $team = app(CreateTeam::class)->execute($workspaceA, $ownerA, 'Team Alpha');
+
+    expect($team->workspace_id)->toBe($workspaceA->id)
+        ->and($team->workspace_id)->not->toBe($workspaceB->id);
+});
+
+test('workspace owner can create team via POST', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $this->actingAs($owner)
+        ->post("/workspaces/{$workspace->id}/teams", ['name' => 'Engineering'])
+        ->assertRedirect();
+
+    expect(Team::where('workspace_id', $workspace->id)->where('name', 'Engineering')->exists())->toBeTrue();
+});
+
+test('workspace viewer cannot create team', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $viewer = User::factory()->create();
+    setPermissionsTeamId($workspace->id);
+    $viewer->assignRole(RoleName::WorkspaceViewer->value);
+
+    $this->actingAs($viewer)
+        ->post("/workspaces/{$workspace->id}/teams", ['name' => 'Engineering'])
+        ->assertForbidden();
+});
+
+test('team name is required', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $this->actingAs($owner)
+        ->post("/workspaces/{$workspace->id}/teams", ['name' => ''])
+        ->assertSessionHasErrors('name');
+});

--- a/tests/Feature/Teams/TeamMemberTest.php
+++ b/tests/Feature/Teams/TeamMemberTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Auth\Domain\Enums\RoleName;
+use App\Modules\Teams\Application\Actions\AddTeamMember;
+use App\Modules\Teams\Application\Actions\CreateTeam;
+use App\Modules\Teams\Application\Actions\RemoveTeamMember;
+use App\Modules\Workspaces\Application\Actions\CreateWorkspace;
+use Illuminate\Auth\Access\AuthorizationException;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function (): void {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    setPermissionsTeamId(null);
+    $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+});
+
+test('workspace member can be added to a team', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $member = User::factory()->create();
+    setPermissionsTeamId($workspace->id);
+    $member->assignRole(RoleName::WorkspaceMember->value);
+
+    $team = app(CreateTeam::class)->execute($workspace, $owner, 'Engineering');
+
+    app(AddTeamMember::class)->execute($team, $member);
+
+    expect($team->members()->where('user_id', $member->id)->exists())->toBeTrue();
+});
+
+test('user without workspace role cannot be added to a team', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $team = app(CreateTeam::class)->execute($workspace, $owner, 'Engineering');
+
+    $outsider = User::factory()->create(); // no workspace role
+
+    expect(fn () => app(AddTeamMember::class)->execute($team, $outsider))
+        ->toThrow(AuthorizationException::class);
+});
+
+test('adding the same member twice is idempotent', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $team = app(CreateTeam::class)->execute($workspace, $owner, 'Engineering');
+
+    app(AddTeamMember::class)->execute($team, $owner); // owner is already a member
+
+    expect($team->members()->where('user_id', $owner->id)->count())->toBe(1);
+});
+
+test('member can be removed from a team', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $member = User::factory()->create();
+    setPermissionsTeamId($workspace->id);
+    $member->assignRole(RoleName::WorkspaceMember->value);
+
+    $team = app(CreateTeam::class)->execute($workspace, $owner, 'Engineering');
+    app(AddTeamMember::class)->execute($team, $member);
+
+    app(RemoveTeamMember::class)->execute($team, $member);
+
+    expect($team->members()->where('user_id', $member->id)->exists())->toBeFalse();
+});
+
+test('team owner cannot be removed', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $team = app(CreateTeam::class)->execute($workspace, $owner, 'Engineering');
+
+    expect(fn () => app(RemoveTeamMember::class)->execute($team, $owner))
+        ->toThrow(AuthorizationException::class);
+});
+
+test('workspace owner can add member via POST', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $member = User::factory()->create();
+    setPermissionsTeamId($workspace->id);
+    $member->assignRole(RoleName::WorkspaceMember->value);
+
+    setPermissionsTeamId($workspace->id);
+    $team = app(CreateTeam::class)->execute($workspace, $owner, 'Engineering');
+
+    $this->actingAs($owner)
+        ->post("/workspaces/{$workspace->id}/teams/{$team->id}/members", [
+            'user_id' => $member->id,
+        ])
+        ->assertRedirect();
+
+    expect($team->members()->where('user_id', $member->id)->exists())->toBeTrue();
+});


### PR DESCRIPTION
- Migration: tabelas teams e team_members
- Team Eloquent model com BelongsToWorkspace trait (tenant-scoped)
- Actions: CreateTeam (owner auto-adicionado), AddTeamMember (valida workspace role), RemoveTeamMember (protege owner)
- TeamController (index/store/show) e TeamMemberController (store/destroy)
- Autorização via permissões Spatie: manage_workspace, invite_members, remove_members
- Rotas aninhadas sob /workspaces/{workspace}/teams/{team}
- Workspace.teams() relationship adicionada
- Páginas Teams/Index e Teams/Show (Inertia/React placeholder)
- TeamFactory para testes
- 12 testes passando (CreateTeam + TeamMember)