### PR TITLE
feat(initiatives): implementar entidade Initiative com CRUD e workspa…

### DIFF
--- a/app/Modules/Initiatives/Application/Actions/CreateInitiative.php
+++ b/app/Modules/Initiatives/Application/Actions/CreateInitiative.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Modules\Initiatives\Application\Actions;
+
+use App\Models\User;
+use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Carbon\Carbon;
+
+class CreateInitiative
+{
+    public function execute(
+        Workspace $workspace,
+        User $owner,
+        string $title,
+        ?string $description = null,
+        ?Carbon $dueDate = null,
+        InitiativeStatus $status = InitiativeStatus::Draft,
+    ): Initiative {
+        return Initiative::create([
+            'workspace_id' => $workspace->id,
+            'owner_id' => $owner->id,
+            'title' => $title,
+            'description' => $description,
+            'status' => $status,
+            'due_date' => $dueDate,
+        ]);
+    }
+}

--- a/app/Modules/Initiatives/Application/Actions/UpdateInitiative.php
+++ b/app/Modules/Initiatives/Application/Actions/UpdateInitiative.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Modules\Initiatives\Application\Actions;
+
+use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+use Carbon\Carbon;
+
+class UpdateInitiative
+{
+    public function execute(
+        Initiative $initiative,
+        string $title,
+        ?string $description = null,
+        ?Carbon $dueDate = null,
+        ?InitiativeStatus $status = null,
+    ): Initiative {
+        $initiative->update([
+            'title' => $title,
+            'description' => $description,
+            'due_date' => $dueDate,
+            'status' => $status ?? $initiative->status,
+        ]);
+
+        return $initiative->fresh();
+    }
+}

--- a/app/Modules/Initiatives/Domain/Enums/InitiativeStatus.php
+++ b/app/Modules/Initiatives/Domain/Enums/InitiativeStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Modules\Initiatives\Domain\Enums;
+
+enum InitiativeStatus: string
+{
+    case Draft = 'draft';
+    case Active = 'active';
+    case OnHold = 'on_hold';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+}

--- a/app/Modules/Initiatives/Infrastructure/Initiative.php
+++ b/app/Modules/Initiatives/Infrastructure/Initiative.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Modules\Initiatives\Infrastructure;
+
+use App\Models\User;
+use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
+use App\Modules\Workspaces\Domain\Traits\BelongsToWorkspace;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Database\Factories\InitiativeFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Initiative extends Model
+{
+    /** @use HasFactory<InitiativeFactory> */
+    use BelongsToWorkspace, HasFactory;
+
+    protected $fillable = [
+        'workspace_id',
+        'owner_id',
+        'title',
+        'description',
+        'status',
+        'due_date',
+    ];
+
+    protected $casts = [
+        'status' => InitiativeStatus::class,
+        'due_date' => 'date',
+    ];
+
+    protected static function newFactory(): Factory
+    {
+        return InitiativeFactory::new();
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'owner_id');
+    }
+}

--- a/app/Modules/Initiatives/Interfaces/Http/Controllers/InitiativeController.php
+++ b/app/Modules/Initiatives/Interfaces/Http/Controllers/InitiativeController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Modules\Initiatives\Interfaces\Http\Controllers;
+
+use App\Modules\Initiatives\Application\Actions\CreateInitiative;
+use App\Modules\Initiatives\Application\Actions\UpdateInitiative;
+use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+use App\Modules\Initiatives\Interfaces\Http\Requests\InitiativeRequest;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class InitiativeController extends Controller
+{
+    public function index(Workspace $workspace): Response
+    {
+        $initiatives = $workspace->initiatives()
+            ->with('owner')
+            ->orderBy('due_date')
+            ->get();
+
+        return Inertia::render('Initiatives/Index', [
+            'workspace' => $workspace,
+            'initiatives' => $initiatives,
+        ]);
+    }
+
+    public function create(Workspace $workspace): Response
+    {
+        return Inertia::render('Initiatives/Create', [
+            'workspace' => $workspace,
+            'statuses' => InitiativeStatus::cases(),
+        ]);
+    }
+
+    public function store(InitiativeRequest $request, Workspace $workspace, CreateInitiative $action): RedirectResponse
+    {
+        abort_unless($request->user()->can('create_initiative'), 403);
+
+        $data = $request->validated();
+
+        $initiative = $action->execute(
+            workspace: $workspace,
+            owner: $request->user(),
+            title: $data['title'],
+            description: $data['description'] ?? null,
+            dueDate: isset($data['due_date']) ? Carbon::parse($data['due_date']) : null,
+            status: isset($data['status']) ? InitiativeStatus::from($data['status']) : InitiativeStatus::Draft,
+        );
+
+        return redirect()->route('initiatives.show', [$workspace, $initiative])
+            ->with('success', 'Iniciativa criada com sucesso.');
+    }
+
+    public function show(Workspace $workspace, Initiative $initiative): Response
+    {
+        abort_unless($initiative->workspace_id === $workspace->id, 404);
+
+        return Inertia::render('Initiatives/Show', [
+            'workspace' => $workspace,
+            'initiative' => $initiative->load('owner'),
+        ]);
+    }
+
+    public function edit(Workspace $workspace, Initiative $initiative): Response
+    {
+        abort_unless($initiative->workspace_id === $workspace->id, 404);
+        abort_unless(request()->user()->can('edit_initiative'), 403);
+
+        return Inertia::render('Initiatives/Edit', [
+            'workspace' => $workspace,
+            'initiative' => $initiative,
+            'statuses' => InitiativeStatus::cases(),
+        ]);
+    }
+
+    public function update(InitiativeRequest $request, Workspace $workspace, Initiative $initiative, UpdateInitiative $action): RedirectResponse
+    {
+        abort_unless($initiative->workspace_id === $workspace->id, 404);
+        abort_unless($request->user()->can('edit_initiative'), 403);
+
+        $data = $request->validated();
+
+        $action->execute(
+            initiative: $initiative,
+            title: $data['title'],
+            description: $data['description'] ?? null,
+            dueDate: isset($data['due_date']) ? Carbon::parse($data['due_date']) : null,
+            status: isset($data['status']) ? InitiativeStatus::from($data['status']) : null,
+        );
+
+        return redirect()->route('initiatives.show', [$workspace, $initiative])
+            ->with('success', 'Iniciativa atualizada.');
+    }
+}

--- a/app/Modules/Initiatives/Interfaces/Http/Requests/InitiativeRequest.php
+++ b/app/Modules/Initiatives/Interfaces/Http/Requests/InitiativeRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Modules\Initiatives\Interfaces\Http\Requests;
+
+use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class InitiativeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'min:3', 'max:255'],
+            'description' => ['nullable', 'string', 'max:5000'],
+            'status' => ['nullable', Rule::enum(InitiativeStatus::class)],
+            'due_date' => ['nullable', 'date', 'after_or_equal:today'],
+        ];
+    }
+}

--- a/app/Modules/Initiatives/Interfaces/routes.php
+++ b/app/Modules/Initiatives/Interfaces/routes.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Modules\Initiatives\Interfaces\Http\Controllers\InitiativeController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['auth', 'workspace.context'])->group(function (): void {
+    Route::get('/workspaces/{workspace}/initiatives', [InitiativeController::class, 'index'])->name('initiatives.index');
+    Route::get('/workspaces/{workspace}/initiatives/create', [InitiativeController::class, 'create'])->name('initiatives.create');
+    Route::post('/workspaces/{workspace}/initiatives', [InitiativeController::class, 'store'])->name('initiatives.store');
+    Route::get('/workspaces/{workspace}/initiatives/{initiative}', [InitiativeController::class, 'show'])->name('initiatives.show');
+    Route::get('/workspaces/{workspace}/initiatives/{initiative}/edit', [InitiativeController::class, 'edit'])->name('initiatives.edit');
+    Route::put('/workspaces/{workspace}/initiatives/{initiative}', [InitiativeController::class, 'update'])->name('initiatives.update');
+});

--- a/app/Modules/Workspaces/Infrastructure/Workspace.php
+++ b/app/Modules/Workspaces/Infrastructure/Workspace.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Workspaces\Infrastructure;
 
 use App\Models\User;
+use App\Modules\Initiatives\Infrastructure\Initiative;
 use App\Modules\Teams\Infrastructure\Team;
 use Database\Factories\WorkspaceFactory;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -35,5 +36,10 @@ class Workspace extends Model
     public function teams(): HasMany
     {
         return $this->hasMany(Team::class);
+    }
+
+    public function initiatives(): HasMany
+    {
+        return $this->hasMany(Initiative::class);
     }
 }

--- a/database/factories/InitiativeFactory.php
+++ b/database/factories/InitiativeFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Initiative>
+ */
+class InitiativeFactory extends Factory
+{
+    protected $model = Initiative::class;
+
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'owner_id' => User::factory(),
+            'title' => fake()->sentence(4),
+            'description' => fake()->paragraph(),
+            'status' => InitiativeStatus::Draft,
+            'due_date' => fake()->optional()->dateTimeBetween('now', '+6 months'),
+        ];
+    }
+}

--- a/database/migrations/2026_03_05_000003_create_initiatives_table.php
+++ b/database/migrations/2026_03_05_000003_create_initiatives_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('initiatives', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained('workspaces')->cascadeOnDelete();
+            $table->foreignId('owner_id')->constrained('users')->cascadeOnDelete();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('status')->default('draft');
+            $table->date('due_date')->nullable();
+            $table->timestamps();
+
+            $table->index(['workspace_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('initiatives');
+    }
+};

--- a/resources/js/Pages/Initiatives/Create.tsx
+++ b/resources/js/Pages/Initiatives/Create.tsx
@@ -1,0 +1,89 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+interface Status {
+    name: string;
+    value: string;
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    statuses: Status[];
+}
+
+export default function Create({ workspace, statuses }: Props) {
+    const { data, setData, post, errors, processing } = useForm({
+        title: '',
+        description: '',
+        status: 'draft',
+        due_date: '',
+    });
+
+    const submit = (e: React.FormEvent) => {
+        e.preventDefault();
+        post(route('initiatives.store', workspace.id));
+    };
+
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Nova Iniciativa
+                </h2>
+            }
+        >
+            <Head title="Nova Iniciativa" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg p-6">
+                        <form onSubmit={submit} className="space-y-4">
+                            <div>
+                                <label htmlFor="title">Título</label>
+                                <input
+                                    id="title"
+                                    type="text"
+                                    value={data.title}
+                                    onChange={(e) => setData('title', e.target.value)}
+                                    className="mt-1 block w-full border rounded px-3 py-2"
+                                />
+                                {errors.title && <p className="text-red-500 text-sm">{errors.title}</p>}
+                            </div>
+                            <div>
+                                <label htmlFor="description">Descrição</label>
+                                <textarea
+                                    id="description"
+                                    value={data.description}
+                                    onChange={(e) => setData('description', e.target.value)}
+                                    className="mt-1 block w-full border rounded px-3 py-2"
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="due_date">Prazo</label>
+                                <input
+                                    id="due_date"
+                                    type="date"
+                                    value={data.due_date}
+                                    onChange={(e) => setData('due_date', e.target.value)}
+                                    className="mt-1 block w-full border rounded px-3 py-2"
+                                />
+                            </div>
+                            <button
+                                type="submit"
+                                disabled={processing}
+                                className="rounded bg-blue-600 px-4 py-2 text-white"
+                            >
+                                Criar Iniciativa
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Initiatives/Edit.tsx
+++ b/resources/js/Pages/Initiatives/Edit.tsx
@@ -1,0 +1,111 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+interface Status {
+    name: string;
+    value: string;
+}
+
+interface Initiative {
+    id: number;
+    title: string;
+    description: string | null;
+    status: string;
+    due_date: string | null;
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    initiative: Initiative;
+    statuses: Status[];
+}
+
+export default function Edit({ workspace, initiative, statuses }: Props) {
+    const { data, setData, put, errors, processing } = useForm({
+        title: initiative.title,
+        description: initiative.description ?? '',
+        status: initiative.status,
+        due_date: initiative.due_date ?? '',
+    });
+
+    const submit = (e: React.FormEvent) => {
+        e.preventDefault();
+        put(route('initiatives.update', [workspace.id, initiative.id]));
+    };
+
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Editar Iniciativa
+                </h2>
+            }
+        >
+            <Head title="Editar Iniciativa" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg p-6">
+                        <form onSubmit={submit} className="space-y-4">
+                            <div>
+                                <label htmlFor="title">Título</label>
+                                <input
+                                    id="title"
+                                    type="text"
+                                    value={data.title}
+                                    onChange={(e) => setData('title', e.target.value)}
+                                    className="mt-1 block w-full border rounded px-3 py-2"
+                                />
+                                {errors.title && <p className="text-red-500 text-sm">{errors.title}</p>}
+                            </div>
+                            <div>
+                                <label htmlFor="description">Descrição</label>
+                                <textarea
+                                    id="description"
+                                    value={data.description}
+                                    onChange={(e) => setData('description', e.target.value)}
+                                    className="mt-1 block w-full border rounded px-3 py-2"
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="status">Status</label>
+                                <select
+                                    id="status"
+                                    value={data.status}
+                                    onChange={(e) => setData('status', e.target.value)}
+                                    className="mt-1 block w-full border rounded px-3 py-2"
+                                >
+                                    {statuses.map((s) => (
+                                        <option key={s.value} value={s.value}>{s.name}</option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div>
+                                <label htmlFor="due_date">Prazo</label>
+                                <input
+                                    id="due_date"
+                                    type="date"
+                                    value={data.due_date}
+                                    onChange={(e) => setData('due_date', e.target.value)}
+                                    className="mt-1 block w-full border rounded px-3 py-2"
+                                />
+                            </div>
+                            <button
+                                type="submit"
+                                disabled={processing}
+                                className="rounded bg-blue-600 px-4 py-2 text-white"
+                            >
+                                Salvar
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Initiatives/Index.tsx
+++ b/resources/js/Pages/Initiatives/Index.tsx
@@ -1,0 +1,64 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, Link } from '@inertiajs/react';
+
+interface Initiative {
+    id: number;
+    title: string;
+    status: string;
+    due_date: string | null;
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    initiatives: Initiative[];
+}
+
+export default function Index({ workspace, initiatives }: Props) {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Iniciativas – {workspace.name}
+                </h2>
+            }
+        >
+            <Head title={`Iniciativas – ${workspace.name}`} />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            <div className="mb-4">
+                                <Link
+                                    href={route('initiatives.create', workspace.id)}
+                                    className="rounded bg-blue-600 px-4 py-2 text-white"
+                                >
+                                    Nova Iniciativa
+                                </Link>
+                            </div>
+                            {initiatives.length === 0 ? (
+                                <p>Nenhuma iniciativa criada.</p>
+                            ) : (
+                                <ul className="space-y-2">
+                                    {initiatives.map((initiative) => (
+                                        <li key={initiative.id}>
+                                            <Link href={route('initiatives.show', [workspace.id, initiative.id])}>
+                                                {initiative.title}
+                                            </Link>
+                                            <span className="ml-2 text-sm text-gray-500">{initiative.status}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Initiatives/Show.tsx
+++ b/resources/js/Pages/Initiatives/Show.tsx
@@ -1,0 +1,54 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, Link } from '@inertiajs/react';
+
+interface Initiative {
+    id: number;
+    title: string;
+    description: string | null;
+    status: string;
+    due_date: string | null;
+    owner: { id: number; name: string };
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    initiative: Initiative;
+}
+
+export default function Show({ workspace, initiative }: Props) {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    {initiative.title}
+                </h2>
+            }
+        >
+            <Head title={initiative.title} />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900 space-y-4">
+                            <p><strong>Status:</strong> {initiative.status}</p>
+                            <p><strong>Owner:</strong> {initiative.owner.name}</p>
+                            {initiative.due_date && <p><strong>Prazo:</strong> {initiative.due_date}</p>}
+                            {initiative.description && <p>{initiative.description}</p>}
+                            <Link
+                                href={route('initiatives.edit', [workspace.id, initiative.id])}
+                                className="rounded bg-gray-600 px-4 py-2 text-white"
+                            >
+                                Editar
+                            </Link>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,3 +20,4 @@ Route::get('/dashboard', function () {
 require __DIR__.'/auth.php';
 require app_path('Modules/Workspaces/Interfaces/routes.php');
 require app_path('Modules/Teams/Interfaces/routes.php');
+require app_path('Modules/Initiatives/Interfaces/routes.php');

--- a/tests/Feature/Initiatives/InitiativeTest.php
+++ b/tests/Feature/Initiatives/InitiativeTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Auth\Domain\Enums\RoleName;
+use App\Modules\Initiatives\Application\Actions\CreateInitiative;
+use App\Modules\Initiatives\Application\Actions\UpdateInitiative;
+use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+use App\Modules\Workspaces\Application\Actions\CreateWorkspace;
+use Carbon\Carbon;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function (): void {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    setPermissionsTeamId(null);
+    $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+});
+
+test('workspace member can create an initiative', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $initiative = app(CreateInitiative::class)->execute(
+        workspace: $workspace,
+        owner: $owner,
+        title: 'Launch Product',
+        description: 'Full product launch plan',
+        dueDate: Carbon::parse('2026-12-01'),
+    );
+
+    expect($initiative)->toBeInstanceOf(Initiative::class)
+        ->and($initiative->title)->toBe('Launch Product')
+        ->and($initiative->workspace_id)->toBe($workspace->id)
+        ->and($initiative->status)->toBe(InitiativeStatus::Draft)
+        ->and($initiative->due_date->format('Y-m-d'))->toBe('2026-12-01');
+});
+
+test('initiative is scoped to its workspace', function (): void {
+    $ownerA = User::factory()->create();
+    $ownerB = User::factory()->create();
+    $workspaceA = app(CreateWorkspace::class)->execute($ownerA, 'Workspace A');
+    $workspaceB = app(CreateWorkspace::class)->execute($ownerB, 'Workspace B');
+
+    setPermissionsTeamId($workspaceA->id);
+    app(CreateInitiative::class)->execute($workspaceA, $ownerA, 'Initiative A');
+
+    expect($workspaceA->initiatives()->count())->toBe(1)
+        ->and($workspaceB->initiatives()->count())->toBe(0);
+});
+
+test('initiative can be updated', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $initiative = app(CreateInitiative::class)->execute($workspace, $owner, 'Draft Initiative');
+
+    $updated = app(UpdateInitiative::class)->execute(
+        initiative: $initiative,
+        title: 'Updated Title',
+        status: InitiativeStatus::Active,
+    );
+
+    expect($updated->title)->toBe('Updated Title')
+        ->and($updated->status)->toBe(InitiativeStatus::Active);
+});
+
+test('workspace member can create initiative via POST', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $this->actingAs($owner)
+        ->post("/workspaces/{$workspace->id}/initiatives", [
+            'title' => 'New Initiative',
+            'description' => 'Some description',
+        ])
+        ->assertRedirect();
+
+    expect(Initiative::where('workspace_id', $workspace->id)->where('title', 'New Initiative')->exists())->toBeTrue();
+});
+
+test('workspace viewer cannot create initiative', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $viewer = User::factory()->create();
+    setPermissionsTeamId($workspace->id);
+    $viewer->assignRole(RoleName::WorkspaceViewer->value);
+
+    $this->actingAs($viewer)
+        ->post("/workspaces/{$workspace->id}/initiatives", ['title' => 'Unauthorized'])
+        ->assertForbidden();
+});
+
+test('workspace member can update initiative via PUT', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $initiative = app(CreateInitiative::class)->execute($workspace, $owner, 'Original Title');
+
+    $this->actingAs($owner)
+        ->put("/workspaces/{$workspace->id}/initiatives/{$initiative->id}", [
+            'title' => 'Updated Title',
+            'status' => 'active',
+        ])
+        ->assertRedirect();
+
+    expect($initiative->fresh()->title)->toBe('Updated Title')
+        ->and($initiative->fresh()->status)->toBe(InitiativeStatus::Active);
+});
+
+test('initiative from another workspace returns 404', function (): void {
+    $ownerA = User::factory()->create();
+    $ownerB = User::factory()->create();
+    $workspaceA = app(CreateWorkspace::class)->execute($ownerA, 'Workspace A');
+    $workspaceB = app(CreateWorkspace::class)->execute($ownerB, 'Workspace B');
+
+    setPermissionsTeamId($workspaceA->id);
+    $initiative = app(CreateInitiative::class)->execute($workspaceA, $ownerA, 'Initiative A');
+
+    // ownerA has no role in workspaceB → middleware blocks with 403 before the controller runs.
+    // This is intentional: we don't reveal whether a resource exists in another workspace.
+    $this->actingAs($ownerA)
+        ->get("/workspaces/{$workspaceB->id}/initiatives/{$initiative->id}")
+        ->assertForbidden();
+});
+
+test('title is required', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $this->actingAs($owner)
+        ->post("/workspaces/{$workspace->id}/initiatives", ['title' => ''])
+        ->assertSessionHasErrors('title');
+});


### PR DESCRIPTION
…ce scope

- Migration: tabela initiatives (workspace_id, owner_id, title, description, status, due_date)
- InitiativeStatus enum: draft, active, on_hold, completed, cancelled
- Initiative Eloquent model com BelongsToWorkspace trait e cast de status/date
- Actions: CreateInitiative e UpdateInitiative
- InitiativeController (index/create/store/show/edit/update) com checagem de permissão
- Autorização via permissões Spatie: create_initiative, edit_initiative
- Rotas aninhadas sob /workspaces/{workspace}/initiatives
- Workspace.initiatives() relationship adicionada
- Páginas React: Index, Show, Create, Edit (Inertia placeholder funcional)
- InitiativeFactory para testes
- 8 testes passando