### PR TITLE
feat(initiatives): implementar Kanban board com drag & drop (closes #7)

### DIFF
--- a/app/Modules/Initiatives/Application/Actions/UpdateInitiativeStatus.php
+++ b/app/Modules/Initiatives/Application/Actions/UpdateInitiativeStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Modules\Initiatives\Application\Actions;
+
+use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+
+class UpdateInitiativeStatus
+{
+    public function execute(Initiative $initiative, InitiativeStatus $status): Initiative
+    {
+        $initiative->update(['status' => $status]);
+
+        return $initiative->fresh();
+    }
+}

--- a/app/Modules/Initiatives/Interfaces/Http/Controllers/InitiativeController.php
+++ b/app/Modules/Initiatives/Interfaces/Http/Controllers/InitiativeController.php
@@ -120,7 +120,7 @@ class InitiativeController extends Controller
         abort_unless($request->user()->can('edit_initiative'), 403);
 
         $request->validate([
-            'status' => ['required', 'string', 'in:' . implode(',', array_column(InitiativeStatus::cases(), 'value'))],
+            'status' => ['required', 'string', 'in:'.implode(',', array_column(InitiativeStatus::cases(), 'value'))],
         ]);
 
         $updated = $action->execute($initiative, InitiativeStatus::from($request->string('status')->toString()));

--- a/app/Modules/Initiatives/Interfaces/Http/Controllers/InitiativeController.php
+++ b/app/Modules/Initiatives/Interfaces/Http/Controllers/InitiativeController.php
@@ -4,12 +4,15 @@ namespace App\Modules\Initiatives\Interfaces\Http\Controllers;
 
 use App\Modules\Initiatives\Application\Actions\CreateInitiative;
 use App\Modules\Initiatives\Application\Actions\UpdateInitiative;
+use App\Modules\Initiatives\Application\Actions\UpdateInitiativeStatus;
 use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
 use App\Modules\Initiatives\Infrastructure\Initiative;
 use App\Modules\Initiatives\Interfaces\Http\Requests\InitiativeRequest;
 use App\Modules\Workspaces\Infrastructure\Workspace;
 use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -95,5 +98,33 @@ class InitiativeController extends Controller
 
         return redirect()->route('initiatives.show', [$workspace, $initiative])
             ->with('success', 'Iniciativa atualizada.');
+    }
+
+    public function kanban(Workspace $workspace): Response
+    {
+        $initiatives = $workspace->initiatives()
+            ->with('owner')
+            ->whereNotIn('status', [InitiativeStatus::Cancelled->value])
+            ->orderBy('due_date')
+            ->get();
+
+        return Inertia::render('Initiatives/Kanban', [
+            'workspace' => $workspace,
+            'initiatives' => $initiatives,
+        ]);
+    }
+
+    public function updateStatus(Request $request, Workspace $workspace, Initiative $initiative, UpdateInitiativeStatus $action): JsonResponse
+    {
+        abort_unless($initiative->workspace_id === $workspace->id, 404);
+        abort_unless($request->user()->can('edit_initiative'), 403);
+
+        $request->validate([
+            'status' => ['required', 'string', 'in:' . implode(',', array_column(InitiativeStatus::cases(), 'value'))],
+        ]);
+
+        $updated = $action->execute($initiative, InitiativeStatus::from($request->string('status')->toString()));
+
+        return response()->json(['status' => $updated->status->value]);
     }
 }

--- a/app/Modules/Initiatives/Interfaces/routes.php
+++ b/app/Modules/Initiatives/Interfaces/routes.php
@@ -5,9 +5,11 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth', 'workspace.context'])->group(function (): void {
     Route::get('/workspaces/{workspace}/initiatives', [InitiativeController::class, 'index'])->name('initiatives.index');
+    Route::get('/workspaces/{workspace}/initiatives/kanban', [InitiativeController::class, 'kanban'])->name('initiatives.kanban');
     Route::get('/workspaces/{workspace}/initiatives/create', [InitiativeController::class, 'create'])->name('initiatives.create');
     Route::post('/workspaces/{workspace}/initiatives', [InitiativeController::class, 'store'])->name('initiatives.store');
     Route::get('/workspaces/{workspace}/initiatives/{initiative}', [InitiativeController::class, 'show'])->name('initiatives.show');
     Route::get('/workspaces/{workspace}/initiatives/{initiative}/edit', [InitiativeController::class, 'edit'])->name('initiatives.edit');
     Route::put('/workspaces/{workspace}/initiatives/{initiative}', [InitiativeController::class, 'update'])->name('initiatives.update');
+    Route::patch('/workspaces/{workspace}/initiatives/{initiative}/status', [InitiativeController::class, 'updateStatus'])->name('initiatives.update-status');
 });

--- a/resources/js/Pages/Initiatives/Index.tsx
+++ b/resources/js/Pages/Initiatives/Index.tsx
@@ -1,6 +1,7 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head, Link } from '@inertiajs/react';
 
+
 interface Initiative {
     id: number;
     title: string;
@@ -33,10 +34,16 @@ export default function Index({ workspace, initiatives }: Props) {
                 <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
                     <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
                         <div className="p-6 text-gray-900">
-                            <div className="mb-4">
+                            <div className="mb-4 flex gap-3">
+                                <Link
+                                    href={route('initiatives.kanban', workspace.id)}
+                                    className="rounded border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+                                >
+                                    Kanban
+                                </Link>
                                 <Link
                                     href={route('initiatives.create', workspace.id)}
-                                    className="rounded bg-blue-600 px-4 py-2 text-white"
+                                    className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
                                 >
                                     Nova Iniciativa
                                 </Link>

--- a/resources/js/Pages/Initiatives/Kanban.tsx
+++ b/resources/js/Pages/Initiatives/Kanban.tsx
@@ -1,0 +1,188 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, Link } from '@inertiajs/react';
+import axios from 'axios';
+import { useState, DragEvent } from 'react';
+
+type InitiativeStatus = 'draft' | 'active' | 'on_hold' | 'completed';
+
+interface Initiative {
+    id: number;
+    title: string;
+    status: InitiativeStatus;
+    due_date: string | null;
+    owner: { name: string } | null;
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    initiatives: Initiative[];
+}
+
+interface Column {
+    id: InitiativeStatus;
+    label: string;
+    color: string;
+    headerColor: string;
+}
+
+const COLUMNS: Column[] = [
+    { id: 'draft', label: 'Backlog', color: 'bg-gray-50', headerColor: 'bg-gray-200 text-gray-700' },
+    { id: 'active', label: 'In Progress', color: 'bg-blue-50', headerColor: 'bg-blue-200 text-blue-800' },
+    { id: 'on_hold', label: 'Review', color: 'bg-yellow-50', headerColor: 'bg-yellow-200 text-yellow-800' },
+    { id: 'completed', label: 'Done', color: 'bg-green-50', headerColor: 'bg-green-200 text-green-800' },
+];
+
+export default function Kanban({ workspace, initiatives: initialInitiatives }: Props) {
+    const [initiatives, setInitiatives] = useState<Initiative[]>(initialInitiatives);
+    const [draggingId, setDraggingId] = useState<number | null>(null);
+    const [dragOverColumn, setDragOverColumn] = useState<InitiativeStatus | null>(null);
+
+    const handleDragStart = (e: DragEvent<HTMLDivElement>, id: number) => {
+        setDraggingId(id);
+        e.dataTransfer.effectAllowed = 'move';
+    };
+
+    const handleDragOver = (e: DragEvent<HTMLDivElement>, columnId: InitiativeStatus) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        setDragOverColumn(columnId);
+    };
+
+    const handleDrop = async (e: DragEvent<HTMLDivElement>, newStatus: InitiativeStatus) => {
+        e.preventDefault();
+        setDragOverColumn(null);
+
+        if (draggingId === null) return;
+
+        const initiative = initiatives.find((i) => i.id === draggingId);
+        if (!initiative || initiative.status === newStatus) return;
+
+        // Optimistic update
+        setInitiatives((prev) =>
+            prev.map((i) => (i.id === draggingId ? { ...i, status: newStatus } : i)),
+        );
+
+        try {
+            await axios.patch(route('initiatives.update-status', [workspace.id, draggingId]), {
+                status: newStatus,
+            });
+        } catch {
+            // Revert on failure
+            setInitiatives((prev) =>
+                prev.map((i) => (i.id === draggingId ? { ...i, status: initiative.status } : i)),
+            );
+        } finally {
+            setDraggingId(null);
+        }
+    };
+
+    const handleDragEnd = () => {
+        setDraggingId(null);
+        setDragOverColumn(null);
+    };
+
+    const initiativesInColumn = (columnId: InitiativeStatus) =>
+        initiatives.filter((i) => i.status === columnId);
+
+    return (
+        <AuthenticatedLayout
+            header={
+                <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                        Kanban – {workspace.name}
+                    </h2>
+                    <div className="flex gap-3 text-sm">
+                        <Link
+                            href={route('initiatives.index', workspace.id)}
+                            className="text-gray-500 hover:text-gray-700"
+                        >
+                            Lista
+                        </Link>
+                        <Link
+                            href={route('initiatives.create', workspace.id)}
+                            className="rounded bg-blue-600 px-3 py-1 text-white hover:bg-blue-700"
+                        >
+                            Nova Iniciativa
+                        </Link>
+                    </div>
+                </div>
+            }
+        >
+            <Head title={`Kanban – ${workspace.name}`} />
+
+            <div className="py-8">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                        {COLUMNS.map((column) => {
+                            const cards = initiativesInColumn(column.id);
+                            const isOver = dragOverColumn === column.id;
+
+                            return (
+                                <div
+                                    key={column.id}
+                                    className={`flex min-h-96 flex-col rounded-lg transition-colors ${column.color} ${isOver ? 'ring-2 ring-blue-400' : ''}`}
+                                    onDragOver={(e) => handleDragOver(e, column.id)}
+                                    onDrop={(e) => handleDrop(e, column.id)}
+                                    onDragLeave={() => setDragOverColumn(null)}
+                                >
+                                    {/* Column header */}
+                                    <div
+                                        className={`flex items-center justify-between rounded-t-lg px-4 py-3 ${column.headerColor}`}
+                                    >
+                                        <span className="font-semibold">{column.label}</span>
+                                        <span className="rounded-full bg-white/60 px-2 py-0.5 text-xs font-medium">
+                                            {cards.length}
+                                        </span>
+                                    </div>
+
+                                    {/* Cards */}
+                                    <div className="flex flex-1 flex-col gap-2 p-3">
+                                        {cards.map((initiative) => (
+                                            <div
+                                                key={initiative.id}
+                                                draggable
+                                                onDragStart={(e) => handleDragStart(e, initiative.id)}
+                                                onDragEnd={handleDragEnd}
+                                                className={`cursor-grab rounded-md bg-white p-3 shadow-sm transition-opacity active:cursor-grabbing ${draggingId === initiative.id ? 'opacity-40' : 'opacity-100'}`}
+                                            >
+                                                <Link
+                                                    href={route('initiatives.show', [workspace.id, initiative.id])}
+                                                    className="block text-sm font-medium text-gray-900 hover:text-blue-600"
+                                                    onClick={(e) => e.stopPropagation()}
+                                                >
+                                                    {initiative.title}
+                                                </Link>
+
+                                                <div className="mt-2 flex items-center justify-between text-xs text-gray-500">
+                                                    {initiative.owner && (
+                                                        <span>{initiative.owner.name}</span>
+                                                    )}
+                                                    {initiative.due_date && (
+                                                        <span>
+                                                            {new Date(initiative.due_date).toLocaleDateString('pt-BR')}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        ))}
+
+                                        {cards.length === 0 && (
+                                            <div className="flex flex-1 items-center justify-center rounded-md border-2 border-dashed border-gray-200 py-8 text-sm text-gray-400">
+                                                Arraste aqui
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/tests/Feature/Initiatives/InitiativeTest.php
+++ b/tests/Feature/Initiatives/InitiativeTest.php
@@ -4,6 +4,7 @@ use App\Models\User;
 use App\Modules\Auth\Domain\Enums\RoleName;
 use App\Modules\Initiatives\Application\Actions\CreateInitiative;
 use App\Modules\Initiatives\Application\Actions\UpdateInitiative;
+use App\Modules\Initiatives\Application\Actions\UpdateInitiativeStatus;
 use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
 use App\Modules\Initiatives\Infrastructure\Initiative;
 use App\Modules\Workspaces\Application\Actions\CreateWorkspace;
@@ -134,4 +135,64 @@ test('title is required', function (): void {
     $this->actingAs($owner)
         ->post("/workspaces/{$workspace->id}/initiatives", ['title' => ''])
         ->assertSessionHasErrors('title');
+});
+
+test('initiative status can be updated via action', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $initiative = app(CreateInitiative::class)->execute($workspace, $owner, 'Draft Initiative');
+
+    $updated = app(UpdateInitiativeStatus::class)->execute($initiative, InitiativeStatus::Active);
+
+    expect($updated->status)->toBe(InitiativeStatus::Active);
+});
+
+test('workspace member can update initiative status via PATCH', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $initiative = app(CreateInitiative::class)->execute($workspace, $owner, 'Kanban Item');
+
+    $this->actingAs($owner)
+        ->patch("/workspaces/{$workspace->id}/initiatives/{$initiative->id}/status", [
+            'status' => 'active',
+        ])
+        ->assertOk()
+        ->assertJson(['status' => 'active']);
+
+    expect($initiative->fresh()->status)->toBe(InitiativeStatus::Active);
+});
+
+test('kanban view returns initiatives grouped by status', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    app(CreateInitiative::class)->execute($workspace, $owner, 'Draft Initiative');
+    $active = app(CreateInitiative::class)->execute($workspace, $owner, 'Active Initiative');
+    app(UpdateInitiativeStatus::class)->execute($active, InitiativeStatus::Active);
+
+    $this->actingAs($owner)
+        ->get("/workspaces/{$workspace->id}/initiatives/kanban")
+        ->assertOk();
+});
+
+test('workspace viewer cannot update initiative status', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $initiative = app(CreateInitiative::class)->execute($workspace, $owner, 'Some Initiative');
+
+    $viewer = User::factory()->create();
+    $viewer->assignRole(RoleName::WorkspaceViewer->value);
+
+    $this->actingAs($viewer)
+        ->patch("/workspaces/{$workspace->id}/initiatives/{$initiative->id}/status", [
+            'status' => 'active',
+        ])
+        ->assertForbidden();
 });


### PR DESCRIPTION
- Adiciona view Kanban com 4 colunas: Backlog, In Progress, Review, Done
- Drag & drop nativo HTML5 com update otimista e rollback em falha
- Action UpdateInitiativeStatus para atualizar status isoladamente
- Rota GET /kanban e PATCH /{initiative}/status no controller
- Link para o Kanban na página de listagem de iniciativas
- 4 novos testes: action, PATCH endpoint, view e autorização