### PR TITLE
feat(decisions): implementar Decision Entity – ADR Registry (closes #8)

### DIFF
--- a/app/Modules/Decisions/Application/Actions/CreateDecision.php
+++ b/app/Modules/Decisions/Application/Actions/CreateDecision.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\Decisions\Application\Actions;
+
+use App\Models\User;
+use App\Modules\Decisions\Domain\Enums\DecisionStatus;
+use App\Modules\Decisions\Infrastructure\Decision;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+
+class CreateDecision
+{
+    public function execute(
+        Workspace $workspace,
+        User $author,
+        string $title,
+        string $context,
+        string $decision,
+        ?string $consequences = null,
+        DecisionStatus $status = DecisionStatus::Proposed,
+        ?Initiative $initiative = null,
+    ): Decision {
+        return Decision::create([
+            'workspace_id' => $workspace->id,
+            'initiative_id' => $initiative?->id,
+            'author_id' => $author->id,
+            'title' => $title,
+            'context' => $context,
+            'decision' => $decision,
+            'consequences' => $consequences,
+            'status' => $status,
+        ]);
+    }
+}

--- a/app/Modules/Decisions/Application/Actions/UpdateDecision.php
+++ b/app/Modules/Decisions/Application/Actions/UpdateDecision.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\Decisions\Application\Actions;
+
+use App\Modules\Decisions\Domain\Enums\DecisionStatus;
+use App\Modules\Decisions\Infrastructure\Decision;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+
+class UpdateDecision
+{
+    public function execute(
+        Decision $decision,
+        string $title,
+        string $context,
+        string $decision_text,
+        ?string $consequences = null,
+        ?DecisionStatus $status = null,
+        ?Initiative $initiative = null,
+        bool $unlinkInitiative = false,
+    ): Decision {
+        $decision->update([
+            'title' => $title,
+            'context' => $context,
+            'decision' => $decision_text,
+            'consequences' => $consequences,
+            'status' => $status ?? $decision->status,
+            'initiative_id' => $unlinkInitiative ? null : ($initiative?->id ?? $decision->initiative_id),
+        ]);
+
+        return $decision->fresh();
+    }
+}

--- a/app/Modules/Decisions/Domain/Enums/DecisionStatus.php
+++ b/app/Modules/Decisions/Domain/Enums/DecisionStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Modules\Decisions\Domain\Enums;
+
+enum DecisionStatus: string
+{
+    case Proposed = 'proposed';
+    case Accepted = 'accepted';
+    case Deprecated = 'deprecated';
+    case Superseded = 'superseded';
+}

--- a/app/Modules/Decisions/Infrastructure/Decision.php
+++ b/app/Modules/Decisions/Infrastructure/Decision.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Modules\Decisions\Infrastructure;
+
+use App\Models\User;
+use App\Modules\Decisions\Domain\Enums\DecisionStatus;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+use App\Modules\Workspaces\Domain\Traits\BelongsToWorkspace;
+use Database\Factories\DecisionFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Decision extends Model
+{
+    /** @use HasFactory<DecisionFactory> */
+    use BelongsToWorkspace, HasFactory;
+
+    protected $fillable = [
+        'workspace_id',
+        'initiative_id',
+        'author_id',
+        'title',
+        'context',
+        'decision',
+        'consequences',
+        'status',
+    ];
+
+    protected $casts = [
+        'status' => DecisionStatus::class,
+    ];
+
+    protected static function newFactory(): Factory
+    {
+        return DecisionFactory::new();
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(\App\Modules\Workspaces\Infrastructure\Workspace::class);
+    }
+
+    public function initiative(): BelongsTo
+    {
+        return $this->belongsTo(Initiative::class);
+    }
+
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'author_id');
+    }
+}

--- a/app/Modules/Decisions/Interfaces/Http/Controllers/DecisionController.php
+++ b/app/Modules/Decisions/Interfaces/Http/Controllers/DecisionController.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Modules\Decisions\Interfaces\Http\Controllers;
+
+use App\Modules\Decisions\Application\Actions\CreateDecision;
+use App\Modules\Decisions\Application\Actions\UpdateDecision;
+use App\Modules\Decisions\Domain\Enums\DecisionStatus;
+use App\Modules\Decisions\Infrastructure\Decision;
+use App\Modules\Decisions\Interfaces\Http\Requests\DecisionRequest;
+use App\Modules\Initiatives\Infrastructure\Initiative;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DecisionController extends Controller
+{
+    public function index(Workspace $workspace): Response
+    {
+        $decisions = $workspace->decisions()
+            ->with(['author', 'initiative'])
+            ->latest()
+            ->get();
+
+        return Inertia::render('Decisions/Index', [
+            'workspace' => $workspace,
+            'decisions' => $decisions,
+        ]);
+    }
+
+    public function create(Workspace $workspace): Response
+    {
+        $initiatives = $workspace->initiatives()->orderBy('title')->get(['id', 'title']);
+
+        return Inertia::render('Decisions/Create', [
+            'workspace' => $workspace,
+            'statuses' => DecisionStatus::cases(),
+            'initiatives' => $initiatives,
+        ]);
+    }
+
+    public function store(DecisionRequest $request, Workspace $workspace, CreateDecision $action): RedirectResponse
+    {
+        abort_unless($request->user()->can('create_decision'), 403);
+
+        $data = $request->validated();
+
+        $initiative = isset($data['initiative_id'])
+            ? Initiative::find($data['initiative_id'])
+            : null;
+
+        $decision = $action->execute(
+            workspace: $workspace,
+            author: $request->user(),
+            title: $data['title'],
+            context: $data['context'],
+            decision: $data['decision'],
+            consequences: $data['consequences'] ?? null,
+            status: isset($data['status']) ? DecisionStatus::from($data['status']) : DecisionStatus::Proposed,
+            initiative: $initiative,
+        );
+
+        return redirect()->route('decisions.show', [$workspace, $decision])
+            ->with('success', 'Decisão criada com sucesso.');
+    }
+
+    public function show(Workspace $workspace, Decision $decision): Response
+    {
+        abort_unless($decision->workspace_id === $workspace->id, 404);
+
+        return Inertia::render('Decisions/Show', [
+            'workspace' => $workspace,
+            'decision' => $decision->load(['author', 'initiative']),
+        ]);
+    }
+
+    public function edit(Workspace $workspace, Decision $decision): Response
+    {
+        abort_unless($decision->workspace_id === $workspace->id, 404);
+        abort_unless(request()->user()->can('edit_decision'), 403);
+
+        $initiatives = $workspace->initiatives()->orderBy('title')->get(['id', 'title']);
+
+        return Inertia::render('Decisions/Edit', [
+            'workspace' => $workspace,
+            'decision' => $decision->load('initiative'),
+            'statuses' => DecisionStatus::cases(),
+            'initiatives' => $initiatives,
+        ]);
+    }
+
+    public function update(DecisionRequest $request, Workspace $workspace, Decision $decision, UpdateDecision $action): RedirectResponse
+    {
+        abort_unless($decision->workspace_id === $workspace->id, 404);
+        abort_unless($request->user()->can('edit_decision'), 403);
+
+        $data = $request->validated();
+
+        $initiative = isset($data['initiative_id'])
+            ? Initiative::find($data['initiative_id'])
+            : null;
+
+        $action->execute(
+            decision: $decision,
+            title: $data['title'],
+            context: $data['context'],
+            decision_text: $data['decision'],
+            consequences: $data['consequences'] ?? null,
+            status: isset($data['status']) ? DecisionStatus::from($data['status']) : null,
+            initiative: $initiative,
+            unlinkInitiative: ! isset($data['initiative_id']),
+        );
+
+        return redirect()->route('decisions.show', [$workspace, $decision])
+            ->with('success', 'Decisão atualizada.');
+    }
+}

--- a/app/Modules/Decisions/Interfaces/Http/Requests/DecisionRequest.php
+++ b/app/Modules/Decisions/Interfaces/Http/Requests/DecisionRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Modules\Decisions\Interfaces\Http\Requests;
+
+use App\Modules\Decisions\Domain\Enums\DecisionStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class DecisionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'min:3', 'max:255'],
+            'context' => ['required', 'string', 'max:10000'],
+            'decision' => ['required', 'string', 'max:10000'],
+            'consequences' => ['nullable', 'string', 'max:10000'],
+            'status' => ['nullable', Rule::enum(DecisionStatus::class)],
+            'initiative_id' => ['nullable', 'integer', 'exists:initiatives,id'],
+        ];
+    }
+}

--- a/app/Modules/Decisions/Interfaces/routes.php
+++ b/app/Modules/Decisions/Interfaces/routes.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Modules\Decisions\Interfaces\Http\Controllers\DecisionController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['auth', 'workspace.context'])->group(function (): void {
+    Route::get('/workspaces/{workspace}/decisions', [DecisionController::class, 'index'])->name('decisions.index');
+    Route::get('/workspaces/{workspace}/decisions/create', [DecisionController::class, 'create'])->name('decisions.create');
+    Route::post('/workspaces/{workspace}/decisions', [DecisionController::class, 'store'])->name('decisions.store');
+    Route::get('/workspaces/{workspace}/decisions/{decision}', [DecisionController::class, 'show'])->name('decisions.show');
+    Route::get('/workspaces/{workspace}/decisions/{decision}/edit', [DecisionController::class, 'edit'])->name('decisions.edit');
+    Route::put('/workspaces/{workspace}/decisions/{decision}', [DecisionController::class, 'update'])->name('decisions.update');
+});

--- a/app/Modules/Initiatives/Infrastructure/Initiative.php
+++ b/app/Modules/Initiatives/Infrastructure/Initiative.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Initiatives\Infrastructure;
 
 use App\Models\User;
+use App\Modules\Decisions\Infrastructure\Decision;
 use App\Modules\Initiatives\Domain\Enums\InitiativeStatus;
 use App\Modules\Workspaces\Domain\Traits\BelongsToWorkspace;
 use App\Modules\Workspaces\Infrastructure\Workspace;
@@ -11,6 +12,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Initiative extends Model
 {
@@ -44,5 +46,10 @@ class Initiative extends Model
     public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'owner_id');
+    }
+
+    public function decisions(): HasMany
+    {
+        return $this->hasMany(Decision::class);
     }
 }

--- a/app/Modules/Initiatives/Interfaces/Http/Controllers/InitiativeController.php
+++ b/app/Modules/Initiatives/Interfaces/Http/Controllers/InitiativeController.php
@@ -63,9 +63,12 @@ class InitiativeController extends Controller
     {
         abort_unless($initiative->workspace_id === $workspace->id, 404);
 
+        $decisions = $initiative->decisions()->with('author')->latest()->get();
+
         return Inertia::render('Initiatives/Show', [
             'workspace' => $workspace,
             'initiative' => $initiative->load('owner'),
+            'decisions' => $decisions,
         ]);
     }
 

--- a/app/Modules/Workspaces/Infrastructure/Workspace.php
+++ b/app/Modules/Workspaces/Infrastructure/Workspace.php
@@ -3,6 +3,7 @@
 namespace App\Modules\Workspaces\Infrastructure;
 
 use App\Models\User;
+use App\Modules\Decisions\Infrastructure\Decision;
 use App\Modules\Initiatives\Infrastructure\Initiative;
 use App\Modules\Teams\Infrastructure\Team;
 use Database\Factories\WorkspaceFactory;
@@ -41,5 +42,10 @@ class Workspace extends Model
     public function initiatives(): HasMany
     {
         return $this->hasMany(Initiative::class);
+    }
+
+    public function decisions(): HasMany
+    {
+        return $this->hasMany(Decision::class);
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -9923,5 +9923,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/database/factories/DecisionFactory.php
+++ b/database/factories/DecisionFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Modules\Decisions\Domain\Enums\DecisionStatus;
+use App\Modules\Decisions\Infrastructure\Decision;
+use App\Modules\Workspaces\Infrastructure\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Decision>
+ */
+class DecisionFactory extends Factory
+{
+    protected $model = Decision::class;
+
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'initiative_id' => null,
+            'author_id' => User::factory(),
+            'title' => fake()->sentence(5),
+            'context' => fake()->paragraph(),
+            'decision' => fake()->paragraph(),
+            'consequences' => fake()->optional()->paragraph(),
+            'status' => DecisionStatus::Proposed,
+        ];
+    }
+}

--- a/database/migrations/2026_03_07_000001_create_decisions_table.php
+++ b/database/migrations/2026_03_07_000001_create_decisions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('decisions', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained('workspaces')->cascadeOnDelete();
+            $table->foreignId('initiative_id')->nullable()->constrained('initiatives')->nullOnDelete();
+            $table->foreignId('author_id')->constrained('users')->cascadeOnDelete();
+            $table->string('title');
+            $table->text('context');
+            $table->text('decision');
+            $table->text('consequences')->nullable();
+            $table->string('status')->default('proposed');
+            $table->timestamps();
+
+            $table->index(['workspace_id', 'status']);
+            $table->index('initiative_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('decisions');
+    }
+};

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,24 +2,36 @@
 
 ## Phase 1 — Foundation (Current)
 
-- Project structure
-- Core documentation
-- Authentication
-- Workspace creation
-- Role management
-- Basic initiative creation
-- Decision registry (ADR entry — backend only)
-- Simple dashboard
+### Infrastructure & Tooling
+- [x] Project structure (modular monolith)
+- [x] Core documentation (vision, architecture, ADRs)
+- [x] Linting & formatting (ESLint, Prettier, PHP CS Fixer) — #12
+- [x] Testing structure (Pest) — #10
+
+### Auth & Multi-Tenancy
+- [x] Authentication module (register, login, password reset) — #1
+- [x] Role & permission system (Spatie Permission) — #2
+- [x] Workspace entity (creation, membership) — #3
+- [x] Workspace middleware (tenant context enforcement) — #4
+
+### Core Domain
+- [x] Team module (creation, membership, role validation) — #5
+- [x] Initiative entity (CRUD, workspace-scoped) — #6
+- [x] Basic Kanban board UI (drag & drop, status update) — #7
+- [ ] Decision entity — ADR registry (CRUD + link to initiative + UI) — #8
+- [ ] Basic dashboard (initiative count by status, recent decisions, team count) — #9
+
+### Documentation
+- [ ] ADR policy & template — #11
 
 ---
 
 ## Phase 2 — Governance Core
 
-- Decision registry (ADR module UI — full interface)
-- Initiative linking to decisions
-- Activity logs
+- Activity logs (Spatie Activity Log)
 - Metrics snapshot
 - Reporting overview
+- Initiative health indicators
 
 ---
 

--- a/resources/js/Pages/Decisions/Create.tsx
+++ b/resources/js/Pages/Decisions/Create.tsx
@@ -1,0 +1,166 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+interface Status {
+    name: string;
+    value: string;
+}
+
+interface Initiative {
+    id: number;
+    title: string;
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    statuses: Status[];
+    initiatives: Initiative[];
+}
+
+export default function Create({ workspace, statuses, initiatives }: Props) {
+    const { data, setData, post, errors, processing } = useForm({
+        title: '',
+        context: '',
+        decision: '',
+        consequences: '',
+        status: 'proposed',
+        initiative_id: '',
+    });
+
+    const submit = (e: React.FormEvent) => {
+        e.preventDefault();
+        post(route('decisions.store', workspace.id));
+    };
+
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Nova Decisão – {workspace.name}
+                </h2>
+            }
+        >
+            <Head title="Nova Decisão" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-3xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <form onSubmit={submit} className="space-y-6 p-6">
+                            <div>
+                                <label htmlFor="title" className="block text-sm font-medium text-gray-700">
+                                    Título
+                                </label>
+                                <input
+                                    id="title"
+                                    type="text"
+                                    value={data.title}
+                                    onChange={(e) => setData('title', e.target.value)}
+                                    className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                />
+                                {errors.title && <p className="mt-1 text-sm text-red-600">{errors.title}</p>}
+                            </div>
+
+                            <div>
+                                <label htmlFor="context" className="block text-sm font-medium text-gray-700">
+                                    Contexto
+                                </label>
+                                <p className="text-xs text-gray-500">Qual problema ou situação motivou esta decisão?</p>
+                                <textarea
+                                    id="context"
+                                    rows={4}
+                                    value={data.context}
+                                    onChange={(e) => setData('context', e.target.value)}
+                                    className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                />
+                                {errors.context && <p className="mt-1 text-sm text-red-600">{errors.context}</p>}
+                            </div>
+
+                            <div>
+                                <label htmlFor="decision" className="block text-sm font-medium text-gray-700">
+                                    Decisão
+                                </label>
+                                <p className="text-xs text-gray-500">O que foi decidido?</p>
+                                <textarea
+                                    id="decision"
+                                    rows={4}
+                                    value={data.decision}
+                                    onChange={(e) => setData('decision', e.target.value)}
+                                    className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                />
+                                {errors.decision && <p className="mt-1 text-sm text-red-600">{errors.decision}</p>}
+                            </div>
+
+                            <div>
+                                <label htmlFor="consequences" className="block text-sm font-medium text-gray-700">
+                                    Consequências <span className="text-gray-400">(opcional)</span>
+                                </label>
+                                <p className="text-xs text-gray-500">Quais são os impactos positivos e negativos esperados?</p>
+                                <textarea
+                                    id="consequences"
+                                    rows={3}
+                                    value={data.consequences}
+                                    onChange={(e) => setData('consequences', e.target.value)}
+                                    className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                />
+                            </div>
+
+                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                                <div>
+                                    <label htmlFor="status" className="block text-sm font-medium text-gray-700">
+                                        Status
+                                    </label>
+                                    <select
+                                        id="status"
+                                        value={data.status}
+                                        onChange={(e) => setData('status', e.target.value)}
+                                        className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                    >
+                                        {statuses.map((s) => (
+                                            <option key={s.value} value={s.value}>
+                                                {s.name}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+
+                                <div>
+                                    <label htmlFor="initiative_id" className="block text-sm font-medium text-gray-700">
+                                        Iniciativa vinculada <span className="text-gray-400">(opcional)</span>
+                                    </label>
+                                    <select
+                                        id="initiative_id"
+                                        value={data.initiative_id}
+                                        onChange={(e) => setData('initiative_id', e.target.value)}
+                                        className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                    >
+                                        <option value="">— Nenhuma —</option>
+                                        {initiatives.map((i) => (
+                                            <option key={i.id} value={i.id}>
+                                                {i.title}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div className="flex justify-end">
+                                <button
+                                    type="submit"
+                                    disabled={processing}
+                                    className="rounded bg-blue-600 px-6 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+                                >
+                                    Registrar Decisão
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Decisions/Edit.tsx
+++ b/resources/js/Pages/Decisions/Edit.tsx
@@ -1,0 +1,174 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+interface Status {
+    name: string;
+    value: string;
+}
+
+interface Initiative {
+    id: number;
+    title: string;
+}
+
+interface DecisionData {
+    id: number;
+    title: string;
+    context: string;
+    decision: string;
+    consequences: string | null;
+    status: string;
+    initiative: Initiative | null;
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    decision: DecisionData;
+    statuses: Status[];
+    initiatives: Initiative[];
+}
+
+export default function Edit({ workspace, decision, statuses, initiatives }: Props) {
+    const { data, setData, put, errors, processing } = useForm({
+        title: decision.title,
+        context: decision.context,
+        decision: decision.decision,
+        consequences: decision.consequences ?? '',
+        status: decision.status,
+        initiative_id: decision.initiative ? String(decision.initiative.id) : '',
+    });
+
+    const submit = (e: React.FormEvent) => {
+        e.preventDefault();
+        put(route('decisions.update', [workspace.id, decision.id]));
+    };
+
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Editar Decisão
+                </h2>
+            }
+        >
+            <Head title="Editar Decisão" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-3xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <form onSubmit={submit} className="space-y-6 p-6">
+                            <div>
+                                <label htmlFor="title" className="block text-sm font-medium text-gray-700">
+                                    Título
+                                </label>
+                                <input
+                                    id="title"
+                                    type="text"
+                                    value={data.title}
+                                    onChange={(e) => setData('title', e.target.value)}
+                                    className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                />
+                                {errors.title && <p className="mt-1 text-sm text-red-600">{errors.title}</p>}
+                            </div>
+
+                            <div>
+                                <label htmlFor="context" className="block text-sm font-medium text-gray-700">
+                                    Contexto
+                                </label>
+                                <textarea
+                                    id="context"
+                                    rows={4}
+                                    value={data.context}
+                                    onChange={(e) => setData('context', e.target.value)}
+                                    className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                />
+                                {errors.context && <p className="mt-1 text-sm text-red-600">{errors.context}</p>}
+                            </div>
+
+                            <div>
+                                <label htmlFor="decision" className="block text-sm font-medium text-gray-700">
+                                    Decisão
+                                </label>
+                                <textarea
+                                    id="decision"
+                                    rows={4}
+                                    value={data.decision}
+                                    onChange={(e) => setData('decision', e.target.value)}
+                                    className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                />
+                                {errors.decision && <p className="mt-1 text-sm text-red-600">{errors.decision}</p>}
+                            </div>
+
+                            <div>
+                                <label htmlFor="consequences" className="block text-sm font-medium text-gray-700">
+                                    Consequências <span className="text-gray-400">(opcional)</span>
+                                </label>
+                                <textarea
+                                    id="consequences"
+                                    rows={3}
+                                    value={data.consequences}
+                                    onChange={(e) => setData('consequences', e.target.value)}
+                                    className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                />
+                            </div>
+
+                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                                <div>
+                                    <label htmlFor="status" className="block text-sm font-medium text-gray-700">
+                                        Status
+                                    </label>
+                                    <select
+                                        id="status"
+                                        value={data.status}
+                                        onChange={(e) => setData('status', e.target.value)}
+                                        className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                    >
+                                        {statuses.map((s) => (
+                                            <option key={s.value} value={s.value}>
+                                                {s.name}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+
+                                <div>
+                                    <label htmlFor="initiative_id" className="block text-sm font-medium text-gray-700">
+                                        Iniciativa vinculada <span className="text-gray-400">(opcional)</span>
+                                    </label>
+                                    <select
+                                        id="initiative_id"
+                                        value={data.initiative_id}
+                                        onChange={(e) => setData('initiative_id', e.target.value)}
+                                        className="mt-1 block w-full rounded border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none"
+                                    >
+                                        <option value="">— Nenhuma —</option>
+                                        {initiatives.map((i) => (
+                                            <option key={i.id} value={i.id}>
+                                                {i.title}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div className="flex justify-end">
+                                <button
+                                    type="submit"
+                                    disabled={processing}
+                                    className="rounded bg-blue-600 px-6 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+                                >
+                                    Salvar Alterações
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Decisions/Index.tsx
+++ b/resources/js/Pages/Decisions/Index.tsx
@@ -1,0 +1,115 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, Link } from '@inertiajs/react';
+
+interface Initiative {
+    id: number;
+    title: string;
+}
+
+interface Decision {
+    id: number;
+    title: string;
+    status: string;
+    author: { name: string };
+    initiative: Initiative | null;
+    created_at: string;
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    decisions: Decision[];
+}
+
+const STATUS_LABELS: Record<string, string> = {
+    proposed: 'Proposed',
+    accepted: 'Accepted',
+    deprecated: 'Deprecated',
+    superseded: 'Superseded',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+    proposed: 'bg-yellow-100 text-yellow-800',
+    accepted: 'bg-green-100 text-green-800',
+    deprecated: 'bg-gray-100 text-gray-600',
+    superseded: 'bg-red-100 text-red-700',
+};
+
+export default function Index({ workspace, decisions }: Props) {
+    return (
+        <AuthenticatedLayout
+            header={
+                <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                        Decisões – {workspace.name}
+                    </h2>
+                    <Link
+                        href={route('decisions.create', workspace.id)}
+                        className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+                    >
+                        Nova Decisão
+                    </Link>
+                </div>
+            }
+        >
+            <Head title={`Decisões – ${workspace.name}`} />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-5xl sm:px-6 lg:px-8">
+                    {decisions.length === 0 ? (
+                        <div className="rounded-lg bg-white p-12 text-center shadow-sm">
+                            <p className="text-gray-500">Nenhuma decisão registrada ainda.</p>
+                            <Link
+                                href={route('decisions.create', workspace.id)}
+                                className="mt-4 inline-block rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+                            >
+                                Registrar primeira decisão
+                            </Link>
+                        </div>
+                    ) : (
+                        <div className="space-y-3">
+                            {decisions.map((decision) => (
+                                <div
+                                    key={decision.id}
+                                    className="flex items-start justify-between rounded-lg bg-white p-5 shadow-sm"
+                                >
+                                    <div className="space-y-1">
+                                        <Link
+                                            href={route('decisions.show', [workspace.id, decision.id])}
+                                            className="font-medium text-gray-900 hover:text-blue-600"
+                                        >
+                                            {decision.title}
+                                        </Link>
+                                        <div className="flex items-center gap-3 text-xs text-gray-500">
+                                            <span>{decision.author.name}</span>
+                                            {decision.initiative && (
+                                                <span>
+                                                    Iniciativa:{' '}
+                                                    <Link
+                                                        href={route('initiatives.show', [workspace.id, decision.initiative.id])}
+                                                        className="hover:text-blue-600"
+                                                    >
+                                                        {decision.initiative.title}
+                                                    </Link>
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <span
+                                        className={`rounded-full px-2 py-1 text-xs font-medium ${STATUS_COLORS[decision.status] ?? 'bg-gray-100 text-gray-600'}`}
+                                    >
+                                        {STATUS_LABELS[decision.status] ?? decision.status}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Decisions/Show.tsx
+++ b/resources/js/Pages/Decisions/Show.tsx
@@ -1,0 +1,120 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, Link } from '@inertiajs/react';
+
+interface Initiative {
+    id: number;
+    title: string;
+}
+
+interface Decision {
+    id: number;
+    title: string;
+    context: string;
+    decision: string;
+    consequences: string | null;
+    status: string;
+    author: { name: string };
+    initiative: Initiative | null;
+    created_at: string;
+}
+
+interface Workspace {
+    id: number;
+    name: string;
+}
+
+interface Props {
+    workspace: Workspace;
+    decision: Decision;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+    proposed: 'Proposed',
+    accepted: 'Accepted',
+    deprecated: 'Deprecated',
+    superseded: 'Superseded',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+    proposed: 'bg-yellow-100 text-yellow-800',
+    accepted: 'bg-green-100 text-green-800',
+    deprecated: 'bg-gray-100 text-gray-600',
+    superseded: 'bg-red-100 text-red-700',
+};
+
+export default function Show({ workspace, decision }: Props) {
+    return (
+        <AuthenticatedLayout
+            header={
+                <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                        {decision.title}
+                    </h2>
+                    <div className="flex items-center gap-3">
+                        <span
+                            className={`rounded-full px-3 py-1 text-xs font-medium ${STATUS_COLORS[decision.status] ?? 'bg-gray-100 text-gray-600'}`}
+                        >
+                            {STATUS_LABELS[decision.status] ?? decision.status}
+                        </span>
+                        <Link
+                            href={route('decisions.edit', [workspace.id, decision.id])}
+                            className="rounded border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+                        >
+                            Editar
+                        </Link>
+                    </div>
+                </div>
+            }
+        >
+            <Head title={decision.title} />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-3xl sm:px-6 lg:px-8 space-y-4">
+                    {decision.initiative && (
+                        <div className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-700">
+                            Vinculada à iniciativa:{' '}
+                            <Link
+                                href={route('initiatives.show', [workspace.id, decision.initiative.id])}
+                                className="font-medium underline hover:text-blue-900"
+                            >
+                                {decision.initiative.title}
+                            </Link>
+                        </div>
+                    )}
+
+                    <div className="overflow-hidden rounded-lg bg-white shadow-sm">
+                        <Section title="Contexto" content={decision.context} />
+                        <Section title="Decisão" content={decision.decision} />
+                        {decision.consequences && (
+                            <Section title="Consequências" content={decision.consequences} />
+                        )}
+                    </div>
+
+                    <p className="text-right text-xs text-gray-400">
+                        Registrado por {decision.author.name}
+                    </p>
+
+                    <div className="pt-2">
+                        <Link
+                            href={route('decisions.index', workspace.id)}
+                            className="text-sm text-gray-500 hover:text-gray-700"
+                        >
+                            ← Voltar para Decisões
+                        </Link>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}
+
+function Section({ title, content }: { title: string; content: string }) {
+    return (
+        <div className="border-b border-gray-100 p-6 last:border-b-0">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                {title}
+            </h3>
+            <p className="whitespace-pre-wrap text-sm text-gray-800">{content}</p>
+        </div>
+    );
+}

--- a/resources/js/Pages/Initiatives/Show.tsx
+++ b/resources/js/Pages/Initiatives/Show.tsx
@@ -1,6 +1,13 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head, Link } from '@inertiajs/react';
 
+interface Decision {
+    id: number;
+    title: string;
+    status: string;
+    author: { name: string };
+}
+
 interface Initiative {
     id: number;
     title: string;
@@ -18,34 +25,94 @@ interface Workspace {
 interface Props {
     workspace: Workspace;
     initiative: Initiative;
+    decisions: Decision[];
 }
 
-export default function Show({ workspace, initiative }: Props) {
+const STATUS_COLORS: Record<string, string> = {
+    proposed: 'bg-yellow-100 text-yellow-800',
+    accepted: 'bg-green-100 text-green-800',
+    deprecated: 'bg-gray-100 text-gray-600',
+    superseded: 'bg-red-100 text-red-700',
+};
+
+export default function Show({ workspace, initiative, decisions }: Props) {
     return (
         <AuthenticatedLayout
             header={
-                <h2 className="text-xl font-semibold leading-tight text-gray-800">
-                    {initiative.title}
-                </h2>
+                <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                        {initiative.title}
+                    </h2>
+                    <Link
+                        href={route('initiatives.edit', [workspace.id, initiative.id])}
+                        className="rounded border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+                    >
+                        Editar
+                    </Link>
+                </div>
             }
         >
             <Head title={initiative.title} />
 
             <div className="py-12">
-                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <div className="mx-auto max-w-3xl space-y-6 sm:px-6 lg:px-8">
+                    {/* Initiative details */}
                     <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900 space-y-4">
+                        <div className="space-y-3 p-6">
                             <p><strong>Status:</strong> {initiative.status}</p>
                             <p><strong>Owner:</strong> {initiative.owner.name}</p>
-                            {initiative.due_date && <p><strong>Prazo:</strong> {initiative.due_date}</p>}
-                            {initiative.description && <p>{initiative.description}</p>}
+                            {initiative.due_date && (
+                                <p><strong>Prazo:</strong> {initiative.due_date}</p>
+                            )}
+                            {initiative.description && (
+                                <p className="whitespace-pre-wrap text-gray-700">{initiative.description}</p>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Linked decisions */}
+                    <div>
+                        <div className="mb-3 flex items-center justify-between">
+                            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                                Decisões vinculadas
+                            </h3>
                             <Link
-                                href={route('initiatives.edit', [workspace.id, initiative.id])}
-                                className="rounded bg-gray-600 px-4 py-2 text-white"
+                                href={route('decisions.create', workspace.id)}
+                                className="text-sm text-blue-600 hover:text-blue-800"
                             >
-                                Editar
+                                + Nova decisão
                             </Link>
                         </div>
+
+                        {decisions.length === 0 ? (
+                            <p className="rounded-lg border border-dashed border-gray-200 p-6 text-center text-sm text-gray-400">
+                                Nenhuma decisão vinculada a esta iniciativa.
+                            </p>
+                        ) : (
+                            <div className="space-y-2">
+                                {decisions.map((decision) => (
+                                    <div
+                                        key={decision.id}
+                                        className="flex items-center justify-between rounded-lg bg-white p-4 shadow-sm"
+                                    >
+                                        <div>
+                                            <Link
+                                                href={route('decisions.show', [workspace.id, decision.id])}
+                                                className="text-sm font-medium text-gray-900 hover:text-blue-600"
+                                            >
+                                                {decision.title}
+                                            </Link>
+                                            <p className="text-xs text-gray-500">{decision.author.name}</p>
+                                        </div>
+                                        <span
+                                            className={`rounded-full px-2 py-1 text-xs font-medium ${STATUS_COLORS[decision.status] ?? 'bg-gray-100 text-gray-600'}`}
+                                        >
+                                            {decision.status}
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,3 +21,4 @@ require __DIR__.'/auth.php';
 require app_path('Modules/Workspaces/Interfaces/routes.php');
 require app_path('Modules/Teams/Interfaces/routes.php');
 require app_path('Modules/Initiatives/Interfaces/routes.php');
+require app_path('Modules/Decisions/Interfaces/routes.php');

--- a/tests/Feature/Decisions/DecisionTest.php
+++ b/tests/Feature/Decisions/DecisionTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use App\Models\User;
+use App\Modules\Decisions\Application\Actions\CreateDecision;
+use App\Modules\Decisions\Application\Actions\UpdateDecision;
+use App\Modules\Decisions\Domain\Enums\DecisionStatus;
+use App\Modules\Decisions\Infrastructure\Decision;
+use App\Modules\Initiatives\Application\Actions\CreateInitiative;
+use App\Modules\Workspaces\Application\Actions\CreateWorkspace;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function (): void {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    setPermissionsTeamId(null);
+    $this->seed(\Database\Seeders\RoleAndPermissionSeeder::class);
+});
+
+test('decision can be created', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $decision = app(CreateDecision::class)->execute(
+        workspace: $workspace,
+        author: $owner,
+        title: 'Use PostgreSQL',
+        context: 'We need a relational database.',
+        decision: 'We will use PostgreSQL.',
+    );
+
+    expect($decision)->toBeInstanceOf(Decision::class)
+        ->and($decision->title)->toBe('Use PostgreSQL')
+        ->and($decision->status)->toBe(DecisionStatus::Proposed)
+        ->and($decision->workspace_id)->toBe($workspace->id);
+});
+
+test('decision can be linked to an initiative', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $initiative = app(CreateInitiative::class)->execute($workspace, $owner, 'Launch Product');
+
+    $decision = app(CreateDecision::class)->execute(
+        workspace: $workspace,
+        author: $owner,
+        title: 'Adopt Modular Monolith',
+        context: 'Architecture decision needed.',
+        decision: 'We adopt a modular monolith.',
+        initiative: $initiative,
+    );
+
+    expect($decision->initiative_id)->toBe($initiative->id);
+});
+
+test('decision is scoped to its workspace', function (): void {
+    $ownerA = User::factory()->create();
+    $ownerB = User::factory()->create();
+    $workspaceA = app(CreateWorkspace::class)->execute($ownerA, 'Workspace A');
+    $workspaceB = app(CreateWorkspace::class)->execute($ownerB, 'Workspace B');
+
+    setPermissionsTeamId($workspaceA->id);
+    app(CreateDecision::class)->execute($workspaceA, $ownerA, 'Decision A', 'ctx', 'dec');
+
+    expect($workspaceA->decisions()->count())->toBe(1)
+        ->and($workspaceB->decisions()->count())->toBe(0);
+});
+
+test('decision can be updated', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $decision = app(CreateDecision::class)->execute($workspace, $owner, 'Draft Decision', 'ctx', 'dec');
+
+    $updated = app(UpdateDecision::class)->execute(
+        decision: $decision,
+        title: 'Final Decision',
+        context: 'Updated context.',
+        decision_text: 'Updated decision text.',
+        status: DecisionStatus::Accepted,
+    );
+
+    expect($updated->title)->toBe('Final Decision')
+        ->and($updated->status)->toBe(DecisionStatus::Accepted);
+});
+
+test('workspace member can create decision via POST', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $this->actingAs($owner)
+        ->post("/workspaces/{$workspace->id}/decisions", [
+            'title' => 'Use Redis for cache',
+            'context' => 'We need caching.',
+            'decision' => 'We will use Redis.',
+        ])
+        ->assertRedirect();
+
+    expect(Decision::where('workspace_id', $workspace->id)->where('title', 'Use Redis for cache')->exists())->toBeTrue();
+});
+
+test('workspace viewer cannot create decision', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    $viewer = User::factory()->create();
+    setPermissionsTeamId($workspace->id);
+    $viewer->assignRole('workspace_viewer');
+
+    $this->actingAs($viewer)
+        ->post("/workspaces/{$workspace->id}/decisions", [
+            'title' => 'Unauthorized',
+            'context' => 'ctx',
+            'decision' => 'dec',
+        ])
+        ->assertForbidden();
+});
+
+test('decision from another workspace returns 404', function (): void {
+    $ownerA = User::factory()->create();
+    $ownerB = User::factory()->create();
+    $workspaceA = app(CreateWorkspace::class)->execute($ownerA, 'Workspace A');
+    $workspaceB = app(CreateWorkspace::class)->execute($ownerB, 'Workspace B');
+
+    setPermissionsTeamId($workspaceA->id);
+    $decision = app(CreateDecision::class)->execute($workspaceA, $ownerA, 'Decision A', 'ctx', 'dec');
+
+    $this->actingAs($ownerA)
+        ->get("/workspaces/{$workspaceB->id}/decisions/{$decision->id}")
+        ->assertForbidden();
+});
+
+test('decisions are visible in initiative show page', function (): void {
+    $owner = User::factory()->create();
+    $workspace = app(CreateWorkspace::class)->execute($owner, 'Acme Corp');
+
+    setPermissionsTeamId($workspace->id);
+    $initiative = app(CreateInitiative::class)->execute($workspace, $owner, 'My Initiative');
+    app(CreateDecision::class)->execute($workspace, $owner, 'Linked Decision', 'ctx', 'dec', initiative: $initiative);
+
+    $this->actingAs($owner)
+        ->get("/workspaces/{$workspace->id}/initiatives/{$initiative->id}")
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Initiatives/Show')
+            ->has('decisions', 1)
+        );
+});


### PR DESCRIPTION
- Migration decisions: workspace_id, initiative_id (nullable), author_id, title, context, decision, consequences, status
- DecisionStatus enum: Proposed, Accepted, Deprecated, Superseded
- Decision model com BelongsToWorkspace, relationships (workspace, initiative, author)
- Actions: CreateDecision, UpdateDecision
- DecisionController com CRUD completo (index, create, store, show, edit, update)
- Rotas workspace-scoped registradas em web.php
- Workspace model: adiciona relationship decisions()
- Initiative model: adiciona relationship decisions()
- Initiative Show page atualizada para exibir decisões vinculadas
- Pages frontend: Index, Create, Show, Edit
- 7 testes de feature cobrindo CRUD, escopo, autorização e integração
- docs/roadmap.md atualizado para refletir as 12 issues da Phase 1