### PR TITLE
feat(dashboard): app shell, auth views redesign & dashboard metrics (closes #9)

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -29,11 +29,15 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
+        $user = $request->user();
+        $workspace = $user?->ownedWorkspaces()->first(['id', 'name', 'slug']);
+
         return [
             ...parent::share($request),
             'auth' => [
-                'user' => $request->user(),
+                'user' => $user,
             ],
+            'currentWorkspace' => $workspace,
         ];
     }
 }

--- a/app/Modules/Reporting/Interfaces/Http/Controllers/DashboardController.php
+++ b/app/Modules/Reporting/Interfaces/Http/Controllers/DashboardController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Modules\Reporting\Interfaces\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DashboardController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $user = auth()->user();
+        $workspace = $user->ownedWorkspaces()->first();
+
+        if (! $workspace) {
+            return Inertia::render('Dashboard', [
+                'workspace' => null,
+                'stats' => null,
+            ]);
+        }
+
+        $initiativesByStatus = $workspace->initiatives()
+            ->selectRaw('status, count(*) as total')
+            ->groupBy('status')
+            ->pluck('total', 'status');
+
+        $recentDecisions = $workspace->decisions()
+            ->with('author:id,name')
+            ->latest()
+            ->take(5)
+            ->get(['id', 'title', 'status', 'created_at', 'author_id']);
+
+        return Inertia::render('Dashboard', [
+            'workspace' => $workspace->only('id', 'name'),
+            'stats' => [
+                'initiative_count' => $workspace->initiatives()->count(),
+                'initiative_by_status' => $initiativesByStatus,
+                'decision_count' => $workspace->decisions()->count(),
+                'team_count' => $workspace->teams()->count(),
+                'recent_decisions' => $recentDecisions,
+            ],
+        ]);
+    }
+}

--- a/app/Modules/Workspaces/Interfaces/Http/Controllers/WorkspaceController.php
+++ b/app/Modules/Workspaces/Interfaces/Http/Controllers/WorkspaceController.php
@@ -12,6 +12,11 @@ use Inertia\Response;
 
 class WorkspaceController extends Controller
 {
+    public function create(): Response
+    {
+        return Inertia::render('Workspaces/Create');
+    }
+
     public function store(CreateWorkspaceRequest $request, CreateWorkspace $action): RedirectResponse
     {
         $workspace = $action->execute(

--- a/app/Modules/Workspaces/Interfaces/routes.php
+++ b/app/Modules/Workspaces/Interfaces/routes.php
@@ -4,6 +4,7 @@ use App\Modules\Workspaces\Interfaces\Http\Controllers\WorkspaceController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth')->group(function (): void {
+    Route::get('/workspaces/create', [WorkspaceController::class, 'create'])->name('workspaces.create');
     Route::post('/workspaces', [WorkspaceController::class, 'store'])->name('workspaces.store');
 
     Route::middleware('workspace.context')->group(function (): void {

--- a/docs/adr/003-root-route-is-login.md
+++ b/docs/adr/003-root-route-is-login.md
@@ -1,0 +1,48 @@
+# ADR-003: Root Route (`/`) Redirects to Login in Phase 1
+
+**Status:** Accepted
+**Date:** 2026-03-07
+
+## Context
+
+Orquestra is a B2B multi-tenant SaaS platform targeting engineering managers and tech leads.
+During Phase 1 (Foundation MVP), there is no billing system, no public onboarding flow,
+and no marketing copy ready for a public-facing landing page.
+
+The question was whether `/` should serve a public landing page or redirect directly to authentication.
+
+## Decision
+
+In Phase 1, the root route `/` redirects:
+- Authenticated users → `/dashboard`
+- Unauthenticated users → `/login`
+
+There is no public landing page in Phase 1.
+
+## Rationale
+
+- **No CTA to support**: A landing page without working billing, plans, or self-serve signup
+  is decorative. It adds maintenance overhead with no user value.
+- **Audience is internal/invited**: Phase 1 users are known — the platform is not yet
+  discoverable or publicly marketed.
+- **Pattern used by comparable tools**: Linear, early Basecamp, early Vercel — all started
+  with login as the entry point before building a marketing layer.
+- **Portfolio value is inside the app**: What impresses reviewers is the dashboard and
+  governance features, not a landing page. The GitHub README and live demo communicate
+  the product vision.
+
+## Consequences
+
+- New visitors who land on `/` are immediately prompted to log in or register.
+- No marketing, pricing, or feature showcase exists at the root URL in Phase 1.
+- The `Welcome.tsx` page (Breeze scaffold) is no longer served and can be removed.
+
+## Future
+
+Phase 2 will introduce a public landing page at `/` with:
+- Product value proposition
+- Feature highlights
+- Pricing plans (tied to Billing module)
+- Self-serve registration CTA
+
+This ADR will be superseded by ADR-006 (planned) when the landing page is implemented.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -1,179 +1,307 @@
-import ApplicationLogo from '@/Components/ApplicationLogo';
-import Dropdown from '@/Components/Dropdown';
-import NavLink from '@/Components/NavLink';
-import ResponsiveNavLink from '@/Components/ResponsiveNavLink';
-import { Link, usePage } from '@inertiajs/react';
+import { PageProps } from '@/types';
+import { Link, router, usePage } from '@inertiajs/react';
 import { PropsWithChildren, ReactNode, useState } from 'react';
 
-export default function Authenticated({
+type SharedProps = PageProps<{
+    currentWorkspace: { id: number; name: string; slug: string } | null;
+}>;
+
+interface NavItem {
+    label: string;
+    href: string;
+    routePattern: string;
+    icon: ReactNode;
+}
+
+function IconHome() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+            <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
+            <polyline points="9 22 9 12 15 12 15 22" />
+        </svg>
+    );
+}
+
+function IconList() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+            <line x1="8" y1="6" x2="21" y2="6" />
+            <line x1="8" y1="12" x2="21" y2="12" />
+            <line x1="8" y1="18" x2="21" y2="18" />
+            <line x1="3" y1="6" x2="3.01" y2="6" />
+            <line x1="3" y1="12" x2="3.01" y2="12" />
+            <line x1="3" y1="18" x2="3.01" y2="18" />
+        </svg>
+    );
+}
+
+function IconKanban() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+            <rect x="3" y="3" width="5" height="18" rx="1" />
+            <rect x="10" y="3" width="5" height="12" rx="1" />
+            <rect x="17" y="3" width="5" height="7" rx="1" />
+        </svg>
+    );
+}
+
+function IconBook() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+            <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
+        </svg>
+    );
+}
+
+function IconUsers() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+            <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+            <circle cx="9" cy="7" r="4" />
+            <path d="M23 21v-2a4 4 0 00-3-3.87" />
+            <path d="M16 3.13a4 4 0 010 7.75" />
+        </svg>
+    );
+}
+
+function IconChevronDown() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+            <polyline points="6 9 12 15 18 9" />
+        </svg>
+    );
+}
+
+function IconMenu() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+    );
+}
+
+function IconX() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+    );
+}
+
+export default function AuthenticatedLayout({
     header,
     children,
 }: PropsWithChildren<{ header?: ReactNode }>) {
-    const user = usePage().props.auth.user;
+    const { auth, currentWorkspace } = usePage<SharedProps>().props;
+    const [sidebarOpen, setSidebarOpen] = useState(false);
+    const [userMenuOpen, setUserMenuOpen] = useState(false);
 
-    const [showingNavigationDropdown, setShowingNavigationDropdown] =
-        useState(false);
+    const wsId = currentWorkspace?.id;
+    const wsName = currentWorkspace?.name ?? 'No workspace';
 
-    return (
-        <div className="min-h-screen bg-gray-100">
-            <nav className="border-b border-gray-100 bg-white">
-                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-                    <div className="flex h-16 justify-between">
-                        <div className="flex">
-                            <div className="flex shrink-0 items-center">
-                                <Link href="/">
-                                    <ApplicationLogo className="block h-9 w-auto fill-current text-gray-800" />
-                                </Link>
-                            </div>
+    const navItems: NavItem[] = [
+        {
+            label: 'Dashboard',
+            href: route('dashboard'),
+            routePattern: 'dashboard',
+            icon: <IconHome />,
+        },
+        ...(wsId
+            ? [
+                  {
+                      label: 'Initiatives',
+                      href: route('initiatives.index', { workspace: wsId }),
+                      routePattern: 'initiatives.*',
+                      icon: <IconList />,
+                  },
+                  {
+                      label: 'Kanban',
+                      href: route('initiatives.kanban', { workspace: wsId }),
+                      routePattern: 'initiatives.kanban',
+                      icon: <IconKanban />,
+                  },
+                  {
+                      label: 'Decisions',
+                      href: route('decisions.index', { workspace: wsId }),
+                      routePattern: 'decisions.*',
+                      icon: <IconBook />,
+                  },
+                  {
+                      label: 'Teams',
+                      href: route('teams.index', { workspace: wsId }),
+                      routePattern: 'teams.*',
+                      icon: <IconUsers />,
+                  },
+              ]
+            : []),
+    ];
 
-                            <div className="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                                <NavLink
-                                    href={route('dashboard')}
-                                    active={route().current('dashboard')}
-                                >
-                                    Dashboard
-                                </NavLink>
-                            </div>
-                        </div>
+    function isActive(routePattern: string): boolean {
+        if (routePattern.endsWith('.*')) {
+            const prefix = routePattern.slice(0, -2);
+            return route().current(prefix + '.*') ?? false;
+        }
+        return route().current(routePattern) ?? false;
+    }
 
-                        <div className="hidden sm:ms-6 sm:flex sm:items-center">
-                            <div className="relative ms-3">
-                                <Dropdown>
-                                    <Dropdown.Trigger>
-                                        <span className="inline-flex rounded-md">
-                                            <button
-                                                type="button"
-                                                className="inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
-                                            >
-                                                {user.name}
+    function handleLogout() {
+        router.post(route('logout'));
+    }
 
-                                                <svg
-                                                    className="-me-0.5 ms-2 h-4 w-4"
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    viewBox="0 0 20 20"
-                                                    fill="currentColor"
-                                                >
-                                                    <path
-                                                        fillRule="evenodd"
-                                                        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                                                        clipRule="evenodd"
-                                                    />
-                                                </svg>
-                                            </button>
-                                        </span>
-                                    </Dropdown.Trigger>
+    const SidebarContent = () => (
+        <div className="flex h-full flex-col">
+            {/* Logo */}
+            <div className="flex h-16 shrink-0 items-center border-b border-[#1E293B] px-6">
+                <Link href={route('dashboard')} className="flex items-center gap-2 focus:outline-none">
+                    <span className="text-lg font-bold tracking-tight text-white">
+                        Orquestra
+                    </span>
+                </Link>
+            </div>
 
-                                    <Dropdown.Content>
-                                        <Dropdown.Link
-                                            href={route('profile.edit')}
-                                        >
-                                            Profile
-                                        </Dropdown.Link>
-                                        <Dropdown.Link
-                                            href={route('logout')}
-                                            method="post"
-                                            as="button"
-                                        >
-                                            Log Out
-                                        </Dropdown.Link>
-                                    </Dropdown.Content>
-                                </Dropdown>
-                            </div>
-                        </div>
-
-                        <div className="-me-2 flex items-center sm:hidden">
-                            <button
-                                onClick={() =>
-                                    setShowingNavigationDropdown(
-                                        (previousState) => !previousState,
-                                    )
-                                }
-                                className="inline-flex items-center justify-center rounded-md p-2 text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none"
-                            >
-                                <svg
-                                    className="h-6 w-6"
-                                    stroke="currentColor"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                >
-                                    <path
-                                        className={
-                                            !showingNavigationDropdown
-                                                ? 'inline-flex'
-                                                : 'hidden'
-                                        }
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth="2"
-                                        d="M4 6h16M4 12h16M4 18h16"
-                                    />
-                                    <path
-                                        className={
-                                            showingNavigationDropdown
-                                                ? 'inline-flex'
-                                                : 'hidden'
-                                        }
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth="2"
-                                        d="M6 18L18 6M6 6l12 12"
-                                    />
-                                </svg>
-                            </button>
-                        </div>
-                    </div>
+            {/* Workspace badge */}
+            {currentWorkspace && (
+                <div className="mx-4 mt-4 rounded-md bg-[#1E293B] px-3 py-2">
+                    <p className="text-xs font-medium text-[#94A3B8]">Workspace</p>
+                    <p className="truncate text-sm font-semibold text-white">{wsName}</p>
                 </div>
-
-                <div
-                    className={
-                        (showingNavigationDropdown ? 'block' : 'hidden') +
-                        ' sm:hidden'
-                    }
-                >
-                    <div className="space-y-1 pb-3 pt-2">
-                        <ResponsiveNavLink
-                            href={route('dashboard')}
-                            active={route().current('dashboard')}
-                        >
-                            Dashboard
-                        </ResponsiveNavLink>
-                    </div>
-
-                    <div className="border-t border-gray-200 pb-1 pt-4">
-                        <div className="px-4">
-                            <div className="text-base font-medium text-gray-800">
-                                {user.name}
-                            </div>
-                            <div className="text-sm font-medium text-gray-500">
-                                {user.email}
-                            </div>
-                        </div>
-
-                        <div className="mt-3 space-y-1">
-                            <ResponsiveNavLink href={route('profile.edit')}>
-                                Profile
-                            </ResponsiveNavLink>
-                            <ResponsiveNavLink
-                                method="post"
-                                href={route('logout')}
-                                as="button"
-                            >
-                                Log Out
-                            </ResponsiveNavLink>
-                        </div>
-                    </div>
-                </div>
-            </nav>
-
-            {header && (
-                <header className="bg-white shadow">
-                    <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-                        {header}
-                    </div>
-                </header>
             )}
 
-            <main>{children}</main>
+            {/* Nav */}
+            <nav className="flex-1 space-y-1 px-3 py-4">
+                {navItems.map((item) => {
+                    const active = isActive(item.routePattern);
+                    return (
+                        <Link
+                            key={item.label}
+                            href={item.href}
+                            onClick={() => setSidebarOpen(false)}
+                            className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-[#0369A1] focus:ring-offset-2 focus:ring-offset-[#0F172A] ${
+                                active
+                                    ? 'bg-[#0369A1] text-white'
+                                    : 'text-[#94A3B8] hover:bg-[#1E293B] hover:text-white'
+                            }`}
+                        >
+                            {item.icon}
+                            {item.label}
+                        </Link>
+                    );
+                })}
+            </nav>
+
+            {/* User section */}
+            <div className="border-t border-[#1E293B] p-4">
+                <div className="relative">
+                    <button
+                        type="button"
+                        onClick={() => setUserMenuOpen((v) => !v)}
+                        className="flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-[#1E293B] focus:outline-none focus:ring-2 focus:ring-[#0369A1] focus:ring-offset-2 focus:ring-offset-[#0F172A]"
+                        aria-label="User menu"
+                    >
+                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#0369A1] text-sm font-semibold text-white">
+                            {auth.user.name.charAt(0).toUpperCase()}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium text-white">
+                                {auth.user.name}
+                            </p>
+                            <p className="truncate text-xs text-[#64748B]">
+                                {auth.user.email}
+                            </p>
+                        </div>
+                        <IconChevronDown />
+                    </button>
+
+                    {userMenuOpen && (
+                        <div className="absolute bottom-full left-0 right-0 mb-1 rounded-md border border-[#1E293B] bg-[#0F172A] py-1 shadow-lg">
+                            <Link
+                                href={route('profile.edit')}
+                                className="block px-4 py-2 text-sm text-[#94A3B8] transition-colors hover:bg-[#1E293B] hover:text-white focus:outline-none"
+                                onClick={() => setUserMenuOpen(false)}
+                            >
+                                Profile
+                            </Link>
+                            <button
+                                type="button"
+                                onClick={handleLogout}
+                                className="block w-full cursor-pointer px-4 py-2 text-left text-sm text-[#94A3B8] transition-colors hover:bg-[#1E293B] hover:text-white focus:outline-none"
+                            >
+                                Sign out
+                            </button>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+
+    return (
+        <div className="flex h-screen overflow-hidden bg-[#F8FAFC]">
+            {/* Mobile overlay */}
+            {sidebarOpen && (
+                <div
+                    className="fixed inset-0 z-20 bg-black/50 lg:hidden"
+                    onClick={() => setSidebarOpen(false)}
+                    aria-hidden="true"
+                />
+            )}
+
+            {/* Mobile sidebar drawer */}
+            <aside
+                className={`fixed inset-y-0 left-0 z-30 w-64 transform bg-[#0F172A] transition-transform duration-200 ease-in-out lg:hidden ${
+                    sidebarOpen ? 'translate-x-0' : '-translate-x-full'
+                }`}
+                aria-label="Sidebar navigation"
+            >
+                <div className="absolute right-3 top-4">
+                    <button
+                        type="button"
+                        onClick={() => setSidebarOpen(false)}
+                        className="cursor-pointer rounded-md p-1 text-[#94A3B8] hover:text-white focus:outline-none"
+                        aria-label="Close sidebar"
+                    >
+                        <IconX />
+                    </button>
+                </div>
+                <SidebarContent />
+            </aside>
+
+            {/* Desktop sidebar */}
+            <aside className="hidden w-64 shrink-0 flex-col bg-[#0F172A] lg:flex">
+                <SidebarContent />
+            </aside>
+
+            {/* Main content */}
+            <div className="flex flex-1 flex-col overflow-hidden">
+                {/* Topbar */}
+                <header className="flex h-16 shrink-0 items-center justify-between border-b border-gray-200 bg-white px-4 sm:px-6">
+                    <div className="flex items-center gap-4">
+                        {/* Mobile menu toggle */}
+                        <button
+                            type="button"
+                            className="cursor-pointer rounded-md p-1 text-[#334155] hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-[#0369A1] lg:hidden"
+                            onClick={() => setSidebarOpen(true)}
+                            aria-label="Open sidebar"
+                        >
+                            <IconMenu />
+                        </button>
+                        {header && (
+                            <div className="text-sm font-medium text-[#0F172A]">
+                                {header}
+                            </div>
+                        )}
+                    </div>
+                </header>
+
+                {/* Page content */}
+                <main className="flex-1 overflow-y-auto p-6">
+                    {children}
+                </main>
+            </div>
         </div>
     );
 }

--- a/resources/js/Layouts/GuestLayout.tsx
+++ b/resources/js/Layouts/GuestLayout.tsx
@@ -1,18 +1,50 @@
-import ApplicationLogo from '@/Components/ApplicationLogo';
-import { Link } from '@inertiajs/react';
 import { PropsWithChildren } from 'react';
 
-export default function Guest({ children }: PropsWithChildren) {
+export default function GuestLayout({ children }: PropsWithChildren) {
     return (
-        <div className="flex min-h-screen flex-col items-center bg-gray-100 pt-6 sm:justify-center sm:pt-0">
-            <div>
-                <Link href="/">
-                    <ApplicationLogo className="h-20 w-20 fill-current text-gray-500" />
-                </Link>
+        <div className="flex min-h-screen">
+            {/* Left — branding panel */}
+            <div className="hidden lg:flex lg:w-1/2 flex-col justify-between bg-[#0F172A] p-12">
+                <div>
+                    <span className="text-white text-2xl font-bold tracking-tight">
+                        Orquestra
+                    </span>
+                </div>
+
+                <div>
+                    <blockquote className="space-y-4">
+                        <p className="text-[#94A3B8] text-lg leading-relaxed">
+                            "Governance over improvisation.
+                            <br />
+                            Clarity over complexity.
+                            <br />
+                            Structure over volume."
+                        </p>
+                        <footer className="text-[#475569] text-sm">
+                            Technical Operations & Governance Platform
+                        </footer>
+                    </blockquote>
+                </div>
+
+                <div className="grid grid-cols-3 gap-4 opacity-30">
+                    <div className="h-1 rounded-full bg-[#0369A1]" />
+                    <div className="h-1 rounded-full bg-[#334155]" />
+                    <div className="h-1 rounded-full bg-[#0369A1]" />
+                </div>
             </div>
 
-            <div className="mt-6 w-full overflow-hidden bg-white px-6 py-4 shadow-md sm:max-w-md sm:rounded-lg">
-                {children}
+            {/* Right — form panel */}
+            <div className="flex flex-1 flex-col items-center justify-center bg-[#F8FAFC] px-6 py-12 lg:px-16">
+                <div className="w-full max-w-sm">
+                    {/* Mobile logo */}
+                    <div className="mb-8 lg:hidden">
+                        <span className="text-[#0F172A] text-2xl font-bold tracking-tight">
+                            Orquestra
+                        </span>
+                    </div>
+
+                    {children}
+                </div>
             </div>
         </div>
     );

--- a/resources/js/Pages/Auth/Login.tsx
+++ b/resources/js/Pages/Auth/Login.tsx
@@ -1,8 +1,4 @@
-import Checkbox from '@/Components/Checkbox';
 import InputError from '@/Components/InputError';
-import InputLabel from '@/Components/InputLabel';
-import PrimaryButton from '@/Components/PrimaryButton';
-import TextInput from '@/Components/TextInput';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
@@ -22,88 +18,114 @@ export default function Login({
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
-
-        post(route('login'), {
-            onFinish: () => reset('password'),
-        });
+        post(route('login'), { onFinish: () => reset('password') });
     };
 
     return (
         <GuestLayout>
-            <Head title="Log in" />
+            <Head title="Sign in" />
+
+            <div className="mb-8">
+                <h1 className="text-2xl font-semibold text-[#020617]">
+                    Sign in
+                </h1>
+                <p className="mt-1 text-sm text-[#475569]">
+                    Don&apos;t have an account?{' '}
+                    <Link
+                        href={route('register')}
+                        className="font-medium text-[#0369A1] hover:underline focus:outline-none"
+                    >
+                        Create one
+                    </Link>
+                </p>
+            </div>
 
             {status && (
-                <div className="mb-4 text-sm font-medium text-green-600">
+                <div className="mb-4 rounded-md bg-green-50 p-3 text-sm text-green-700">
                     {status}
                 </div>
             )}
 
-            <form onSubmit={submit}>
+            <form onSubmit={submit} className="space-y-5">
                 <div>
-                    <InputLabel htmlFor="email" value="Email" />
-
-                    <TextInput
+                    <label
+                        htmlFor="email"
+                        className="block text-sm font-medium text-[#0F172A]"
+                    >
+                        Email
+                    </label>
+                    <input
                         id="email"
                         type="email"
                         name="email"
                         value={data.email}
-                        className="mt-1 block w-full"
                         autoComplete="username"
-                        isFocused={true}
+                        autoFocus
                         onChange={(e) => setData('email', e.target.value)}
+                        className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-[#020617] placeholder-gray-400 shadow-sm transition-colors focus:border-[#0369A1] focus:outline-none focus:ring-1 focus:ring-[#0369A1]"
+                        placeholder="you@company.com"
                     />
-
-                    <InputError message={errors.email} className="mt-2" />
+                    <InputError message={errors.email} className="mt-1" />
                 </div>
 
-                <div className="mt-4">
-                    <InputLabel htmlFor="password" value="Password" />
-
-                    <TextInput
+                <div>
+                    <div className="flex items-center justify-between">
+                        <label
+                            htmlFor="password"
+                            className="block text-sm font-medium text-[#0F172A]"
+                        >
+                            Password
+                        </label>
+                        {canResetPassword && (
+                            <Link
+                                href={route('password.request')}
+                                className="text-xs text-[#0369A1] hover:underline focus:outline-none"
+                            >
+                                Forgot password?
+                            </Link>
+                        )}
+                    </div>
+                    <input
                         id="password"
                         type="password"
                         name="password"
                         value={data.password}
-                        className="mt-1 block w-full"
                         autoComplete="current-password"
                         onChange={(e) => setData('password', e.target.value)}
+                        className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-[#020617] shadow-sm transition-colors focus:border-[#0369A1] focus:outline-none focus:ring-1 focus:ring-[#0369A1]"
                     />
-
-                    <InputError message={errors.password} className="mt-2" />
+                    <InputError message={errors.password} className="mt-1" />
                 </div>
 
-                <div className="mt-4 block">
-                    <label className="flex items-center">
-                        <Checkbox
-                            name="remember"
-                            checked={data.remember}
-                            onChange={(e) =>
-                                setData(
-                                    'remember',
-                                    (e.target.checked || false) as false,
-                                )
-                            }
-                        />
-                        <span className="ms-2 text-sm text-gray-600">
-                            Remember me
-                        </span>
+                <div className="flex items-center gap-2">
+                    <input
+                        id="remember"
+                        type="checkbox"
+                        name="remember"
+                        checked={data.remember}
+                        onChange={(e) =>
+                            setData(
+                                'remember',
+                                (e.target.checked || false) as false,
+                            )
+                        }
+                        className="h-4 w-4 cursor-pointer rounded border-gray-300 text-[#0369A1] focus:ring-[#0369A1]"
+                    />
+                    <label
+                        htmlFor="remember"
+                        className="cursor-pointer text-sm text-[#475569]"
+                    >
+                        Remember me
                     </label>
                 </div>
 
-                <div className="mt-4 flex items-center justify-end">
-                    {canResetPassword && (
-                        <Link
-                            href={route('password.request')}
-                            className="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                        >
-                            Forgot your password?
-                        </Link>
-                    )}
-
-                    <PrimaryButton className="ms-4" disabled={processing}>
-                        Log in
-                    </PrimaryButton>
-                </div>
+                <button
+                    type="submit"
+                    disabled={processing}
+                    className="flex w-full cursor-pointer items-center justify-center rounded-md bg-[#0369A1] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#0284C7] focus:outline-none focus:ring-2 focus:ring-[#0369A1] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                    {processing ? 'Signing in…' : 'Sign in'}
+                </button>
             </form>
         </GuestLayout>
     );

--- a/resources/js/Pages/Auth/Register.tsx
+++ b/resources/js/Pages/Auth/Register.tsx
@@ -1,7 +1,4 @@
 import InputError from '@/Components/InputError';
-import InputLabel from '@/Components/InputLabel';
-import PrimaryButton from '@/Components/PrimaryButton';
-import TextInput from '@/Components/TextInput';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
@@ -16,7 +13,6 @@ export default function Register() {
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
-
         post(route('register'), {
             onFinish: () => reset('password', 'password_confirmation'),
         });
@@ -24,97 +20,119 @@ export default function Register() {
 
     return (
         <GuestLayout>
-            <Head title="Register" />
+            <Head title="Create account" />
 
-            <form onSubmit={submit}>
+            <div className="mb-8">
+                <h1 className="text-2xl font-semibold text-[#020617]">
+                    Create account
+                </h1>
+                <p className="mt-1 text-sm text-[#475569]">
+                    Already have an account?{' '}
+                    <Link
+                        href={route('login')}
+                        className="font-medium text-[#0369A1] hover:underline focus:outline-none"
+                    >
+                        Sign in
+                    </Link>
+                </p>
+            </div>
+
+            <form onSubmit={submit} className="space-y-5">
                 <div>
-                    <InputLabel htmlFor="name" value="Name" />
-
-                    <TextInput
+                    <label
+                        htmlFor="name"
+                        className="block text-sm font-medium text-[#0F172A]"
+                    >
+                        Full name
+                    </label>
+                    <input
                         id="name"
+                        type="text"
                         name="name"
                         value={data.name}
-                        className="mt-1 block w-full"
                         autoComplete="name"
-                        isFocused={true}
+                        autoFocus
                         onChange={(e) => setData('name', e.target.value)}
                         required
+                        className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-[#020617] placeholder-gray-400 shadow-sm transition-colors focus:border-[#0369A1] focus:outline-none focus:ring-1 focus:ring-[#0369A1]"
+                        placeholder="Jane Smith"
                     />
-
-                    <InputError message={errors.name} className="mt-2" />
+                    <InputError message={errors.name} className="mt-1" />
                 </div>
 
-                <div className="mt-4">
-                    <InputLabel htmlFor="email" value="Email" />
-
-                    <TextInput
+                <div>
+                    <label
+                        htmlFor="email"
+                        className="block text-sm font-medium text-[#0F172A]"
+                    >
+                        Email
+                    </label>
+                    <input
                         id="email"
                         type="email"
                         name="email"
                         value={data.email}
-                        className="mt-1 block w-full"
                         autoComplete="username"
                         onChange={(e) => setData('email', e.target.value)}
                         required
+                        className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-[#020617] placeholder-gray-400 shadow-sm transition-colors focus:border-[#0369A1] focus:outline-none focus:ring-1 focus:ring-[#0369A1]"
+                        placeholder="you@company.com"
                     />
-
-                    <InputError message={errors.email} className="mt-2" />
+                    <InputError message={errors.email} className="mt-1" />
                 </div>
 
-                <div className="mt-4">
-                    <InputLabel htmlFor="password" value="Password" />
-
-                    <TextInput
+                <div>
+                    <label
+                        htmlFor="password"
+                        className="block text-sm font-medium text-[#0F172A]"
+                    >
+                        Password
+                    </label>
+                    <input
                         id="password"
                         type="password"
                         name="password"
                         value={data.password}
-                        className="mt-1 block w-full"
                         autoComplete="new-password"
                         onChange={(e) => setData('password', e.target.value)}
                         required
+                        className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-[#020617] shadow-sm transition-colors focus:border-[#0369A1] focus:outline-none focus:ring-1 focus:ring-[#0369A1]"
                     />
-
-                    <InputError message={errors.password} className="mt-2" />
+                    <InputError message={errors.password} className="mt-1" />
                 </div>
 
-                <div className="mt-4">
-                    <InputLabel
+                <div>
+                    <label
                         htmlFor="password_confirmation"
-                        value="Confirm Password"
-                    />
-
-                    <TextInput
+                        className="block text-sm font-medium text-[#0F172A]"
+                    >
+                        Confirm password
+                    </label>
+                    <input
                         id="password_confirmation"
                         type="password"
                         name="password_confirmation"
                         value={data.password_confirmation}
-                        className="mt-1 block w-full"
                         autoComplete="new-password"
                         onChange={(e) =>
                             setData('password_confirmation', e.target.value)
                         }
                         required
+                        className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-[#020617] shadow-sm transition-colors focus:border-[#0369A1] focus:outline-none focus:ring-1 focus:ring-[#0369A1]"
                     />
-
                     <InputError
                         message={errors.password_confirmation}
-                        className="mt-2"
+                        className="mt-1"
                     />
                 </div>
 
-                <div className="mt-4 flex items-center justify-end">
-                    <Link
-                        href={route('login')}
-                        className="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                    >
-                        Already registered?
-                    </Link>
-
-                    <PrimaryButton className="ms-4" disabled={processing}>
-                        Register
-                    </PrimaryButton>
-                </div>
+                <button
+                    type="submit"
+                    disabled={processing}
+                    className="flex w-full cursor-pointer items-center justify-center rounded-md bg-[#0369A1] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#0284C7] focus:outline-none focus:ring-2 focus:ring-[#0369A1] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                    {processing ? 'Creating account…' : 'Create account'}
+                </button>
             </form>
         </GuestLayout>
     );

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -91,7 +91,7 @@ function EmptyState({ workspaceId }: { workspaceId?: number }) {
                 Create a workspace to start organizing your team&apos;s work.
             </p>
             <Link
-                href={route('workspaces.store')}
+                href={route('workspaces.create')}
                 className="mt-6 cursor-pointer rounded-md bg-[#0369A1] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0284C7] focus:outline-none focus:ring-2 focus:ring-[#0369A1] focus:ring-offset-2"
             >
                 Create workspace

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -1,26 +1,236 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head } from '@inertiajs/react';
+import { PageProps } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
+
+interface RecentDecision {
+    id: number;
+    title: string;
+    status: string;
+    created_at: string;
+    author: { name: string } | null;
+}
+
+interface Stats {
+    initiative_count: number;
+    initiative_by_status: Record<string, number>;
+    decision_count: number;
+    team_count: number;
+    recent_decisions: RecentDecision[];
+}
+
+type DashboardProps = PageProps<{
+    workspace: { id: number; name: string } | null;
+    stats: Stats | null;
+}>;
+
+const STATUS_LABELS: Record<string, string> = {
+    draft: 'Draft',
+    active: 'Active',
+    on_hold: 'On Hold',
+    completed: 'Completed',
+    cancelled: 'Cancelled',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+    draft: 'bg-gray-100 text-gray-600',
+    active: 'bg-blue-100 text-blue-700',
+    on_hold: 'bg-yellow-100 text-yellow-700',
+    completed: 'bg-green-100 text-green-700',
+    cancelled: 'bg-red-100 text-red-600',
+};
+
+const DECISION_STATUS_COLORS: Record<string, string> = {
+    proposed: 'bg-blue-100 text-blue-700',
+    accepted: 'bg-green-100 text-green-700',
+    deprecated: 'bg-yellow-100 text-yellow-700',
+    superseded: 'bg-gray-100 text-gray-600',
+};
+
+function StatCard({
+    label,
+    value,
+    href,
+}: {
+    label: string;
+    value: number;
+    href?: string;
+}) {
+    const inner = (
+        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md">
+            <p className="text-sm font-medium text-[#475569]">{label}</p>
+            <p className="mt-2 text-3xl font-semibold text-[#020617]">
+                {value}
+            </p>
+        </div>
+    );
+
+    if (href) {
+        return (
+            <Link href={href} className="cursor-pointer focus:outline-none focus:ring-2 focus:ring-[#0369A1] focus:ring-offset-2 rounded-lg block">
+                {inner}
+            </Link>
+        );
+    }
+
+    return inner;
+}
+
+function EmptyState({ workspaceId }: { workspaceId?: number }) {
+    return (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-white py-16 text-center">
+            <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[#F1F5F9]">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#94A3B8" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" className="h-7 w-7">
+                    <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
+                    <polyline points="9 22 9 12 15 12 15 22" />
+                </svg>
+            </div>
+            <h3 className="text-base font-semibold text-[#0F172A]">
+                No workspace yet
+            </h3>
+            <p className="mt-1 text-sm text-[#475569]">
+                Create a workspace to start organizing your team&apos;s work.
+            </p>
+            <Link
+                href={route('workspaces.store')}
+                className="mt-6 cursor-pointer rounded-md bg-[#0369A1] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0284C7] focus:outline-none focus:ring-2 focus:ring-[#0369A1] focus:ring-offset-2"
+            >
+                Create workspace
+            </Link>
+        </div>
+    );
+}
 
 export default function Dashboard() {
+    const { workspace, stats } = usePage<DashboardProps>().props;
+
+    const allStatuses = ['draft', 'active', 'on_hold', 'completed', 'cancelled'];
+
     return (
-        <AuthenticatedLayout
-            header={
-                <h2 className="text-xl font-semibold leading-tight text-gray-800">
-                    Dashboard
-                </h2>
-            }
-        >
+        <AuthenticatedLayout header="Dashboard">
             <Head title="Dashboard" />
 
-            <div className="py-12">
-                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
-                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">
-                            You're logged in!
+            {!workspace || !stats ? (
+                <EmptyState />
+            ) : (
+                <div className="space-y-8">
+                    {/* Stat cards */}
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                        <StatCard
+                            label="Initiatives"
+                            value={stats.initiative_count}
+                            href={route('initiatives.index', { workspace: workspace.id })}
+                        />
+                        <StatCard
+                            label="Decisions"
+                            value={stats.decision_count}
+                            href={route('decisions.index', { workspace: workspace.id })}
+                        />
+                        <StatCard
+                            label="Teams"
+                            value={stats.team_count}
+                            href={route('teams.index', { workspace: workspace.id })}
+                        />
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                        {/* Initiatives by status */}
+                        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+                            <div className="mb-4 flex items-center justify-between">
+                                <h2 className="text-sm font-semibold text-[#0F172A]">
+                                    Initiatives by status
+                                </h2>
+                                <Link
+                                    href={route('initiatives.index', { workspace: workspace.id })}
+                                    className="cursor-pointer text-xs font-medium text-[#0369A1] hover:underline focus:outline-none"
+                                >
+                                    View all
+                                </Link>
+                            </div>
+
+                            {stats.initiative_count === 0 ? (
+                                <p className="py-6 text-center text-sm text-[#94A3B8]">
+                                    No initiatives yet.
+                                </p>
+                            ) : (
+                                <div className="space-y-3">
+                                    {allStatuses.map((status) => {
+                                        const count = stats.initiative_by_status[status] ?? 0;
+                                        if (count === 0) return null;
+                                        const pct = Math.round((count / stats.initiative_count) * 100);
+                                        return (
+                                            <div key={status}>
+                                                <div className="mb-1 flex items-center justify-between text-xs">
+                                                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[status]}`}>
+                                                        {STATUS_LABELS[status]}
+                                                    </span>
+                                                    <span className="text-[#475569]">
+                                                        {count} ({pct}%)
+                                                    </span>
+                                                </div>
+                                                <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+                                                    <div
+                                                        className="h-full rounded-full bg-[#0369A1] transition-all"
+                                                        style={{ width: `${pct}%` }}
+                                                    />
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Recent decisions */}
+                        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+                            <div className="mb-4 flex items-center justify-between">
+                                <h2 className="text-sm font-semibold text-[#0F172A]">
+                                    Recent decisions
+                                </h2>
+                                <Link
+                                    href={route('decisions.index', { workspace: workspace.id })}
+                                    className="cursor-pointer text-xs font-medium text-[#0369A1] hover:underline focus:outline-none"
+                                >
+                                    View all
+                                </Link>
+                            </div>
+
+                            {stats.recent_decisions.length === 0 ? (
+                                <p className="py-6 text-center text-sm text-[#94A3B8]">
+                                    No decisions recorded yet.
+                                </p>
+                            ) : (
+                                <ul className="divide-y divide-gray-100">
+                                    {stats.recent_decisions.map((d) => (
+                                        <li key={d.id} className="py-3 first:pt-0 last:pb-0">
+                                            <Link
+                                                href={route('decisions.show', { workspace: workspace.id, decision: d.id })}
+                                                className="group cursor-pointer focus:outline-none"
+                                            >
+                                                <div className="flex items-start justify-between gap-2">
+                                                    <p className="text-sm font-medium text-[#0F172A] group-hover:text-[#0369A1] transition-colors">
+                                                        {d.title}
+                                                    </p>
+                                                    <span className={`shrink-0 inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${DECISION_STATUS_COLORS[d.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                                                        {d.status.charAt(0).toUpperCase() + d.status.slice(1)}
+                                                    </span>
+                                                </div>
+                                                <p className="mt-0.5 text-xs text-[#94A3B8]">
+                                                    {d.author?.name ?? 'Unknown'} &middot;{' '}
+                                                    {new Date(d.created_at).toLocaleDateString('en-US', {
+                                                        month: 'short',
+                                                        day: 'numeric',
+                                                        year: 'numeric',
+                                                    })}
+                                                </p>
+                                            </Link>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
                         </div>
                     </div>
                 </div>
-            </div>
+            )}
         </AuthenticatedLayout>
     );
 }

--- a/resources/js/Pages/Workspaces/Create.tsx
+++ b/resources/js/Pages/Workspaces/Create.tsx
@@ -1,0 +1,70 @@
+import InputError from '@/Components/InputError';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, Link, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+
+export default function Create() {
+    const { data, setData, post, processing, errors } = useForm({
+        name: '',
+    });
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        post(route('workspaces.store'));
+    };
+
+    return (
+        <AuthenticatedLayout header="New workspace">
+            <Head title="New workspace" />
+
+            <div className="mx-auto max-w-lg">
+                <div className="rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
+                    <h1 className="text-lg font-semibold text-[#0F172A]">
+                        Create a workspace
+                    </h1>
+                    <p className="mt-1 text-sm text-[#475569]">
+                        A workspace groups your teams, initiatives, and decisions.
+                    </p>
+
+                    <form onSubmit={submit} className="mt-6 space-y-5">
+                        <div>
+                            <label
+                                htmlFor="name"
+                                className="block text-sm font-medium text-[#0F172A]"
+                            >
+                                Workspace name
+                            </label>
+                            <input
+                                id="name"
+                                type="text"
+                                name="name"
+                                value={data.name}
+                                autoFocus
+                                onChange={(e) => setData('name', e.target.value)}
+                                placeholder="e.g. Acme Engineering"
+                                className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-[#020617] placeholder-gray-400 shadow-sm transition-colors focus:border-[#0369A1] focus:outline-none focus:ring-1 focus:ring-[#0369A1]"
+                            />
+                            <InputError message={errors.name} className="mt-1" />
+                        </div>
+
+                        <div className="flex items-center justify-end gap-3 pt-2">
+                            <Link
+                                href={route('dashboard')}
+                                className="cursor-pointer text-sm text-[#475569] hover:text-[#0F172A] focus:outline-none"
+                            >
+                                Cancel
+                            </Link>
+                            <button
+                                type="submit"
+                                disabled={processing}
+                                className="cursor-pointer rounded-md bg-[#0369A1] px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#0284C7] focus:outline-none focus:ring-2 focus:ring-[#0369A1] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                                {processing ? 'Creating…' : 'Create workspace'}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,21 +1,17 @@
 <?php
 
-use Illuminate\Foundation\Application;
+use App\Modules\Reporting\Interfaces\Http\Controllers\DashboardController;
 use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
 
 Route::get('/', function () {
-    return Inertia::render('Welcome', [
-        'canLogin' => Route::has('login'),
-        'canRegister' => Route::has('register'),
-        'laravelVersion' => Application::VERSION,
-        'phpVersion' => PHP_VERSION,
-    ]);
+    return auth()->check()
+        ? redirect()->route('dashboard')
+        : redirect()->route('login');
 });
 
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('/dashboard', DashboardController::class)
+    ->middleware(['auth', 'verified'])
+    ->name('dashboard');
 
 require __DIR__.'/auth.php';
 require app_path('Modules/Workspaces/Interfaces/routes.php');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,7 +13,16 @@ export default {
     theme: {
         extend: {
             fontFamily: {
-                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
+                sans: ['Plus Jakarta Sans', ...defaultTheme.fontFamily.sans],
+            },
+            colors: {
+                brand: {
+                    primary: '#0F172A',
+                    secondary: '#334155',
+                    cta: '#0369A1',
+                    bg: '#F8FAFC',
+                    text: '#020617',
+                },
             },
         },
     },

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,7 +1,7 @@
 <?php
 
-it('returns a successful response', function () {
+it('root redirects unauthenticated users to login', function () {
     $response = $this->get('/');
 
-    $response->assertStatus(200);
+    $response->assertRedirect(route('login'));
 });


### PR DESCRIPTION
## Summary

- `ADR-003`: Documenta decisão de `/ = login` na Phase 1 — landing pública adiada para Phase 2
- `web.php`: raiz redireciona guest→login, autenticado→dashboard
- `DashboardController`: métricas de workspace (initiatives por status, decisions recentes, team count)
- `HandleInertiaRequests`: compartilha `currentWorkspace` nos shared props do Inertia
- `AuthenticatedLayout`: reescrito como sidebar lateral escura com nav completa, workspace badge e user menu
- `GuestLayout`: reescrito como split panel — branding à esquerda, form à direita
- `Login` / `Register`: redesenho completo com design system Trust & Authority
- `Dashboard`: 3 stat cards + progress bars por status de iniciativa + lista de decisions recentes com link
- Tailwind: fonte Plus Jakarta Sans + brand colors (`#0F172A` / `#0369A1` / `#F8FAFC`)

**Design system via UI/UX Pro Max skill:**
- Style: Trust & Authority (B2B governance, professional)
- Palette: primary `#0F172A`, CTA `#0369A1`, bg `#F8FAFC`
- Typography: Plus Jakarta Sans (friendly, modern SaaS)

## Components Changed

- [ ] Agent (Go)
- [ ] API (Python)
- [x] Frontend (React)
- [x] Infra / Config

## Test Plan

- [x] TypeScript: `npm run type-check` passando
- [x] PHP: Pint passando em todos arquivos editados
- [x] `ExampleTest` atualizado (/ agora é 302 → /login)
- [x] Testado manualmente — dashboard carrega, sidebar funciona, auth views redesenhadas

## Notes

30 testes pré-existentes continuam falhando (CSRF/session issues) — não introduzidos por este PR.
ADR-003 documenta a decisão de routing para Phase 1.

Closes #9