### PR TITLE
docs: expand roadmap phases 2-5, add skills doc and governance vision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,11 @@ Garante: design system coerente, WCAG AA, responsivo, 67 estilos, 96 paletas.
 
 ## Key Docs
 
-- `docs/vision.md` — product vision and principles
-- `docs/roadmap.md` — phase breakdown with issue numbers
+- `docs/vision.md` — product vision, principles, and **why this is not a task manager**
+- `docs/roadmap.md` — all phases with issue numbers (Phase 1–5 + long-term vision)
 - `docs/architecture.md` — architectural overview
-- `docs/adr/` — ADRs 001 (modular monolith) and 002 (layer conventions)
+- `docs/skills.md` — all available Claude Code skills with usage and examples
+- `docs/adr/001-modular-monolith.md` — ADR: modular monolith architecture
+- `docs/adr/002-module-layer-conventions.md` — ADR: layer responsibilities and naming
+- `docs/adr/003-root-route-is-login.md` — ADR: `/` redirects to login in Phase 1
 - `docs/portfolio-strategy.md` — broader portfolio context (personal reference)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,16 +1,18 @@
 # Roadmap
 
-## Phase 1 — Foundation (Current)
+## Phase 1 — Foundation MVP *(current)*
+
+> Auth, multi-tenancy, core domain entities, basic UI. The building blocks everything else depends on.
 
 ### Infrastructure & Tooling
 - [x] Project structure (modular monolith)
 - [x] Core documentation (vision, architecture, ADRs)
-- [x] Linting & formatting (ESLint, Prettier, PHP CS Fixer) — #12
-- [x] Testing structure (Pest) — #10
+- [ ] Setup Testing Structure (Pest) — #10
+- [ ] Setup Linting & Formatting (ESLint, Prettier, Pint) — #12
 
 ### Auth & Multi-Tenancy
 - [x] Authentication module (register, login, password reset) — #1
-- [x] Role & permission system (Spatie Permission) — #2
+- [x] Role & permission system (Spatie Permission, workspace-scoped) — #2
 - [x] Workspace entity (creation, membership) — #3
 - [x] Workspace middleware (tenant context enforcement) — #4
 
@@ -18,44 +20,101 @@
 - [x] Team module (creation, membership, role validation) — #5
 - [x] Initiative entity (CRUD, workspace-scoped) — #6
 - [x] Basic Kanban board UI (drag & drop, status update) — #7
-- [ ] Decision entity — ADR registry (CRUD + link to initiative + UI) — #8
-- [ ] Basic dashboard (initiative count by status, recent decisions, team count) — #9
+- [x] Decision entity — ADR registry (CRUD + link to initiative + UI) — #8
+- [x] Basic dashboard (initiative count by status, recent decisions, team count) — #9
 
 ### Documentation
 - [ ] ADR policy & template — #11
 
 ---
 
-## Phase 2 — Governance Core
+## Phase 2 — Governance Intelligence
 
-- Activity logs (Spatie Activity Log)
-- Metrics snapshot
-- Reporting overview
-- Initiative health indicators
+> This is what makes Orquestra a governance platform, not a task manager.
+> Phase 1 builds the data model. Phase 2 makes that data tell a story.
+
+### Activity & Audit
+- [ ] Activity log UI — full visible audit trail per entity (initiative, decision, team) — #27
+- [ ] Decision status lifecycle (PROPOSED → ACCEPTED / REJECTED / SUPERSEDED → IMPLEMENTED) — #28
+
+### Initiative Health
+- [ ] Initiative health score algorithm (activity recency, open decisions, overdue threshold) — #29
+- [ ] Health indicators on Kanban board (colour-coded, hover detail) — #30
+- [ ] Health indicators on dashboard (score distribution, at-risk initiatives list) — #30 *(same issue)*
+
+### Governance Compliance
+- [ ] Decision-to-Initiative mandatory linking (decisions must belong to an initiative) — #31
+- [ ] Process templates (governance checklists per initiative type) — #32
+- [ ] Governance compliance view per initiative (decisions made, pending, template adherence) — #33
+
+### Public Presence
+- [ ] Public landing page at `/` — value proposition, highlights, CTA — #34
+  *Supersedes ADR-003 as noted in that document.*
 
 ---
 
-## Phase 3 — Operational Intelligence
+## Phase 3 — Visibility & Reporting
 
-- Initiative health scoring
-- Technical debt tracking
-- Basic analytics
-- Historical reporting
+> Teams that can't measure their governance can't improve it.
+> Reporting is the bridge between data and decisions.
+
+### Reporting Module
+- [ ] Reporting module scaffold (PDF/Excel generation infrastructure) — #35
+- [ ] Governance report PDF export per workspace — #36
+- [ ] CSV/Excel export for initiatives and decisions — #37
+- [ ] Advanced governance KPI dashboard (trends, resolution rates, debt age) — #43
+
+### Visibility Features
+- [ ] Technical debt tagging (decisions and initiatives flagged as tech debt, with age) — #38
+- [ ] ADR timeline view (visual chronological view of decisions per initiative/workspace) — #39
+- [ ] Workspace governance health report (aggregate: all initiatives, all decisions) — #43 *(same issue)*
+
+### Async Notifications
+- [ ] Queue workers setup (Laravel queues + Redis driver infrastructure) — #40
+- [ ] Email notifications (workspace events: decisions created, health score dropped, etc.) — #41
+- [ ] Slack / Discord webhook notifications (configurable per workspace) — #42
 
 ---
 
-## Phase 4 — Advanced Governance
+## Phase 4 — API & Integrations
 
-- Feature flags module
-- Billing module
-- API exposure
-- Public documentation
+> Orquestra stops being an island. Governance decisions drive action in external systems.
+
+### REST API
+- [ ] REST API scaffold (Laravel Sanctum, token-per-workspace, versioned routes) — #44
+- [ ] Initiatives API (CRUD + filtering + health score exposure) — #45
+- [ ] Decisions API (CRUD + filtering + lifecycle transitions) — #46
+- [ ] OpenAPI documentation (Scribe, auto-generated) — #49
+
+### Webhooks & Integrations
+- [ ] Webhook emitter (domain events → configurable external endpoint per workspace) — #47
+- [ ] Aegis integration — decisions generate tracked work items via Aegis ticket API — #48
+  *Requires Aegis Phase 1 (ticket CRUD + REST API) to be complete.*
+  *Workflow: decision → "Generate ticket" → Aegis API → client system polls Aegis for their tickets.*
+- [ ] Sentinel SDK integration (feature flags per workspace via Sentinel PHP SDK) — #50
+  *Requires Sentinel Phase 1 (Go server + PHP SDK) to be complete.*
+
+### Developer Tooling
+- [ ] CLI tooling (`orquestra adr list`, `orquestra initiative show`, etc.) — #51
+
+---
+
+## Phase 5 — Monetization
+
+> Orquestra becomes a commercial product.
+
+- [ ] Billing module scaffold (domain model: plans, subscriptions, limits) — #52
+- [ ] Stripe subscriptions integration (checkout, billing portal, webhooks) — #53
+- [ ] Workspace tier system and usage limits enforcement — #54
+- [ ] Billing UI (plans page, invoice history, payment method management) — #55
+- [ ] Process template marketplace (community templates, import/fork) — #56
 
 ---
 
 ## Long-Term Vision
 
-- Public API
-- CLI integration
-- Advanced metrics engine
-- Possible extraction of modules into services
+- Public API ecosystem (third-party governance integrations)
+- SDK for embedding governance widgets into client applications
+- Advanced metrics engine (workspace-level SLOs for governance quality)
+- Cross-workspace benchmarking (opt-in: how does your team compare?)
+- Possible extraction of high-traffic modules into microservices

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,125 @@
+# Claude Code Skills — Orquestra
+
+Skills are slash commands available inside Claude Code sessions on this project.
+They are defined in `.claude/commands/` and invoked with `/skill-name`.
+
+---
+
+## Available Skills
+
+### `/sprint <issue-number(s)>`
+
+**Purpose:** Start a sprint. Reads the issue(s), creates the correct feature branch, consults relevant docs, and presents an implementation plan for approval before writing any code.
+
+**When to use:** At the beginning of every work session on a new issue.
+
+**What it does:**
+1. Reads each issue via `gh issue view <number>`
+2. Verifies current branch — switches to `develop` and pulls if needed
+3. Creates the feature branch: `feature/<issue-slug>` (or a shared slug for related issues)
+4. Consults `docs/roadmap.md`, `docs/adr/002-module-layer-conventions.md`, and `CLAUDE.md`
+5. Presents a plan: files to create, files to modify, implementation order, tests needed
+6. Waits for approval before writing code
+
+**Examples:**
+```bash
+/sprint 13        # single issue
+/sprint 13 14 15  # multiple related issues in one sprint
+```
+
+**Rules enforced:**
+- Never starts coding without an approved plan
+- Always creates a feature branch before touching any file
+- Runs `vendor/bin/pint --test` before every commit
+- Runs `npm run type-check` before every commit that touches `.tsx` files
+
+---
+
+### `/pr`
+
+**Purpose:** Create a Pull Request from the current feature branch to `develop`, following the project's PR template.
+
+**When to use:** After all commits for the current issue(s) are done and tests pass.
+
+**What it does:**
+1. Reads `git diff develop...HEAD` and `git log` to understand all changes
+2. Generates a PR title (under 70 chars) and structured body
+3. Pushes the branch to origin if not already pushed
+4. Creates the PR via `gh pr create` with:
+   - Summary (bullet points of what changed and why)
+   - Test plan (checklist of what was tested)
+
+**PR body format:**
+```markdown
+## Summary
+- bullet points
+
+## Test plan
+- [ ] checklist items
+
+🤖 Generated with Claude Code
+```
+
+---
+
+### `/new-module <ModuleName>`
+
+**Purpose:** Scaffold a new module following the 4-layer modular monolith architecture.
+
+**When to use:** When starting implementation of a new domain module (e.g., `Reporting`, `Billing`).
+
+**What it creates:**
+```
+app/Modules/<ModuleName>/
+├── Domain/
+│   └── .gitkeep
+├── Application/
+│   └── .gitkeep
+├── Infrastructure/
+│   └── .gitkeep
+└── Interfaces/
+    ├── Http/
+    │   ├── Controllers/
+    │   └── Requests/
+    └── routes.php
+```
+
+**What it registers:**
+- Registers `routes.php` in `routes/web.php`
+- Optionally creates a base migration if a model is needed
+
+**Example:**
+```bash
+/new-module Reporting
+/new-module Billing
+/new-module FeatureFlags
+```
+
+**Layer responsibilities** (from ADR-002):
+
+| Layer | Contents | Rule |
+|---|---|---|
+| `Domain/` | Enums, Value Objects, Events | No framework dependencies |
+| `Application/` | Actions (use cases) | Named as verbs: `CreateInitiative`, `UpdateDecisionStatus` |
+| `Infrastructure/` | Eloquent models, factories, repos | Framework-dependent implementations |
+| `Interfaces/` | Controllers, Requests, routes.php | Thin — orchestrates, does not contain logic |
+
+---
+
+## UI/UX Pro Max (external skill)
+
+For any frontend work — components, layouts, pages, design system decisions — activate the **UI/UX Pro Max** skill.
+
+**Source:** https://github.com/nextlevelbuilder/ui-ux-pro-max-skill
+
+**Guarantees:** WCAG AA accessibility, responsive design, coherent design system, 67 styles, 96 palettes.
+
+**When to activate:** Any time a `.tsx` file is created or significantly modified as part of a feature.
+
+---
+
+## Notes
+
+- Skills live in `.claude/commands/` as markdown files
+- They are loaded automatically by Claude Code in this project
+- If a skill behaves unexpectedly, check `.claude/commands/<skill-name>.md` for the current definition

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -49,7 +49,31 @@ Orquestra aims to centralize governance without increasing bureaucracy.
 
 ---
 
-## 5. Architecture Model
+## 5. Why Orquestra is Not a Task Manager
+
+This distinction is not cosmetic. It shapes every feature priority decision.
+
+A task manager answers: **what needs to be done?**
+Orquestra answers: **are we making good decisions, and can we prove it?**
+
+| Task Manager | Orquestra |
+|---|---|
+| Creates tasks, moves status | Tracks *why* a decision was made, who decided, what alternatives were considered |
+| Assigns work to people | Establishes decision authority and accountability per workspace |
+| Shows deadline vs. completion | Calculates initiative health: activity recency, open decisions, overdue governance |
+| Activity log is optional | Full audit trail is mandatory — every change is traceable via Spatie Activity Log |
+| Dashboard shows task counts | Governance reports: X decisions this quarter, Y unresolved, Z initiatives at risk |
+| No concept of process compliance | Compliance view: did this initiative follow the required governance checklist? |
+| Technical debt is invisible | Decisions and initiatives can be explicitly tagged as technical debt, with age tracking |
+| Kanban is the product | Kanban is the surface — governance intelligence is the product |
+
+The Kanban board exists because initiatives have statuses. But health scoring, decision lifecycle, process templates, audit trails, and governance reports are what make Orquestra a governance tool.
+
+The integration story reinforces this: a governance decision in Orquestra can generate a tracked work item in Aegis, which a client system (e.g., a Fleet Management platform) then consumes and acts on. Task managers don't close loops across systems.
+
+---
+
+## 6. Architecture Model
 
 **Architecture Style:** Modular Monolith
 
@@ -62,7 +86,7 @@ Orquestra aims to centralize governance without increasing bureaucracy.
 
 ---
 
-## 6. Multi-Tenant Strategy
+## 7. Multi-Tenant Strategy
 
 **Tenant Model:** Workspace-based isolation
 
@@ -75,7 +99,7 @@ No database-per-tenant strategy at this stage.
 
 ---
 
-## 7. Technology Stack
+## 8. Technology Stack
 
 ### Backend
 - Laravel 12
@@ -104,7 +128,7 @@ No database-per-tenant strategy at this stage.
 
 ---
 
-## 8. Initial Domain Modules
+## 9. Initial Domain Modules
 
 ```
 app/Modules/
@@ -125,7 +149,7 @@ Each module must:
 
 ---
 
-## 9. Initial MVP Scope (Phase 1)
+## 10. Initial MVP Scope (Phase 1)
 
 - User authentication
 - Workspace creation
@@ -139,7 +163,7 @@ Each module must:
 
 ---
 
-## 10. Documentation Standards
+## 11. Documentation Standards
 
 Orquestra follows documentation-first governance.
 
@@ -163,7 +187,7 @@ chore(scope): description
 
 ---
 
-## 11. Internationalization Policy
+## 12. Internationalization Policy
 
 - Interface prepared for i18n (pt-BR / en)
 - Primary documentation in English
@@ -172,7 +196,7 @@ chore(scope): description
 
 ---
 
-## 12. Guiding Principles
+## 13. Guiding Principles
 
 > Governance over improvisation.
 > Clarity over complexity.
@@ -182,4 +206,4 @@ chore(scope): description
 
 ---
 
-*Orquestra Base Document v0.1*
+*Orquestra Base Document v0.2 — updated 2026-03-09*


### PR DESCRIPTION
## Summary

- **roadmap.md**: full expansion of Phases 2–5 with 30 numbered GitHub issues (milestones created for phases 2–5)
- **vision.md**: new section *Why Orquestra is not a task manager* — concrete feature comparison table, governance differentiators, and the Aegis integration story
- **docs/skills.md**: new document covering all Claude Code skills (`/sprint`, `/pr`, `/new-module`) with usage, parameters, examples, and the layer responsibility table from ADR-002
- **CLAUDE.md**: Key Docs section updated to include ADR-003, `docs/skills.md`, and improved descriptions

## GitHub Issues Created
- Phase 2 (Governance Intelligence): #27–#34 → milestone #2
- Phase 3 (Visibility & Reporting): #35–#43 → milestone #3
- Phase 4 (API & Integrations): #44–#51 → milestone #4
- Phase 5 (Monetization): #52–#56 → milestone #5

## Test plan
- [x] All links in CLAUDE.md Key Docs resolve to existing files
- [x] roadmap.md issue numbers match created GitHub issues
- [x] docs/skills.md accurately describes current skill behaviour